### PR TITLE
Docker の CODEX_HOME defaults seed を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,13 @@ WORKDIR /app
 COPY package.json package-lock.json tsconfig.json ./
 RUN npm ci
 
+COPY AGENTS.md ./
+COPY .codex ./.codex
 COPY src ./src
 COPY docs ./docs
 COPY tests ./tests
 COPY README.md ./
+COPY docker/codex-home-defaults /opt/codex-home-defaults
 
 COPY docker/entrypoint.sh /usr/local/bin/codex-agent-entrypoint
 RUN chmod +x /usr/local/bin/codex-agent-entrypoint

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Docker では次を使います。
 - SQLite: `./.docker/data/app.sqlite`
 - app / worker の作業ディレクトリ: `/app`
 
+Docker 内の rules/skills は 2 層です。
+
+- project local: `/app/AGENTS.md`, `/app/.codex/skills`
+- Docker 用 `CODEX_HOME` defaults: `docker/codex-home-defaults/`
+
+container 起動時は `docker/codex-home-defaults/` だけを `~/.codex` に初回 seed します。global rules の実体は `~/.codex/AGENTS.md` で、`~/AGENTS.md` はその symlink として扱います。`/app/.codex/skills` をそのまま複製はしません。既存の `CODEX_HOME` 側ファイルは保持され、repo 更新で自動上書きはしません。
+
 詳細は [docs/docker.md](./docs/docker.md) を参照してください。
 
 開発時:

--- a/docker/codex-home-defaults/AGENTS.md
+++ b/docker/codex-home-defaults/AGENTS.md
@@ -1,0 +1,7 @@
+# Docker Codex Home Defaults
+
+- このファイルは Docker 起動時に `~/AGENTS.md` へ初回 seed される。
+- `/app` はソースコード、`~/.codex` は Docker 内 Codex の永続 state と custom skills の置き場。
+- `/app/AGENTS.md` と `/app/.codex/skills` は project local の定義であり、ここから自動複製しない。
+- `playwright-cli` を使うときは、最初のコマンドから named session を使い、作業後は `close` で閉じる。
+- Slack の画像返信検証では、2回目以降は既存の `/tmp/...png` を返す経路を優先する。

--- a/docker/codex-home-defaults/skills/playwright-cli-docker/SKILL.md
+++ b/docker/codex-home-defaults/skills/playwright-cli-docker/SKILL.md
@@ -1,0 +1,11 @@
+# playwright-cli-docker
+
+Docker 内の `playwright-cli` 実行に限定した補助 skill。
+
+## 使い方
+
+- 最初のコマンドから `-s=<name>` で named session を使う。
+- 基本手順は `open` または `goto` → 必要な操作 → `screenshot --filename=/tmp/...png` → `close`。
+- `--help` の実行は避け、必要なら既存 knowledge か短いコマンドで確認する。
+- Slack の画像返信機能を再検証するときは、新しいスクショを毎回撮らず、既にある `/tmp/...png` をそのまま返す指示を優先する。
+- 手動ログインが必要な確認では headed 実行を使い、profile は container の既定 path に保存される前提で扱う。

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,6 +23,68 @@ prune_dangling_skill_symlinks() {
   done < <(find "${skills_dir}" -type l -print0)
 }
 
+seed_file_if_missing() {
+  local src="$1"
+  local dest="$2"
+  if [[ ! -f "${src}" || -e "${dest}" ]]; then
+    return
+  fi
+
+  mkdir -p "$(dirname "${dest}")"
+  cp "${src}" "${dest}"
+  echo "seeded file: ${dest}" >&2
+}
+
+seed_children_if_missing() {
+  local src_dir="$1"
+  local dest_dir="$2"
+  if [[ ! -d "${src_dir}" ]]; then
+    return
+  fi
+
+  mkdir -p "${dest_dir}"
+
+  while IFS= read -r -d '' src_path; do
+    local name
+    local dest_path
+    name="$(basename "${src_path}")"
+    dest_path="${dest_dir}/${name}"
+    if [[ -e "${dest_path}" ]]; then
+      continue
+    fi
+
+    cp -R "${src_path}" "${dest_path}"
+    echo "seeded path: ${dest_path}" >&2
+  done < <(find "${src_dir}" -mindepth 1 -maxdepth 1 -print0)
+}
+
+ensure_home_agents_link() {
+  local codex_home="${CODEX_HOME:-/root/.codex}"
+  local codex_home_agents="${codex_home}/AGENTS.md"
+  local root_agents="${HOME:-/root}/AGENTS.md"
+
+  if [[ -f "${root_agents}" && ! -e "${codex_home_agents}" && ! -L "${root_agents}" ]]; then
+    mkdir -p "${codex_home}"
+    cp "${root_agents}" "${codex_home_agents}"
+    echo "migrated file: ${root_agents} -> ${codex_home_agents}" >&2
+  fi
+
+  if [[ -e "${root_agents}" && ! -L "${root_agents}" ]]; then
+    rm -f "${root_agents}"
+  fi
+
+  ln -sfn "${codex_home_agents}" "${root_agents}"
+}
+
+seed_codex_home_defaults() {
+  local codex_home="${CODEX_HOME:-/root/.codex}"
+  local defaults_dir="${CODEX_HOME_DEFAULTS_DIR:-/opt/codex-home-defaults}"
+
+  seed_file_if_missing "${defaults_dir}/AGENTS.md" "${codex_home}/AGENTS.md"
+  seed_children_if_missing "${defaults_dir}/skills" "${codex_home}/skills"
+  ensure_home_agents_link
+}
+
 mkdir -p "${CODEX_HOME:-/root/.codex}"
 mkdir -p "${PLAYWRIGHT_AGENT_PROFILE_DIR:-/profiles/agent}"
 mkdir -p "$(dirname "${SQLITE_PATH:-/data/app.sqlite}")"
@@ -32,6 +94,7 @@ require_env SLACK_BOT_TOKEN
 require_env SLACK_APP_TOKEN
 
 prune_dangling_skill_symlinks
+seed_codex_home_defaults
 
 cat > "${PLAYWRIGHT_MCP_CONFIG:-/run/playwright/cli.config.json}" <<EOF
 {
@@ -39,7 +102,8 @@ cat > "${PLAYWRIGHT_MCP_CONFIG:-/run/playwright/cli.config.json}" <<EOF
     "browserName": "chromium",
     "userDataDir": "${PLAYWRIGHT_AGENT_PROFILE_DIR:-/profiles/agent}",
     "launchOptions": {
-      "executablePath": "/usr/bin/chromium"
+      "executablePath": "/usr/bin/chromium",
+      "chromiumSandbox": false
     }
   }
 }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -18,8 +18,24 @@ app 自体は image 内の `/app` で動作し、Codex worker の作業対象も
 - Codex 認証: `./.docker/codex-home`
 - Playwright agent profile: `./.docker/playwright-agent-profile`
 - SQLite: `./.docker/data/app.sqlite`
+- project local rules/skills: `/app/AGENTS.md`, `/app/.codex/skills`
+- Docker 用 `CODEX_HOME` defaults: `docker/codex-home-defaults/`
 
 これらは bind mount です。host の通常 `.codex` や普段使いの Chrome profile は共有しません。
+
+## rules / skills の扱い
+
+Docker では rules / skills を次の 2 層で分けます。
+
+- `/app/AGENTS.md`, `/app/.codex/skills`
+  - repo に含まれる project local 定義
+- `docker/codex-home-defaults/`
+  - `~/.codex/AGENTS.md`, `~/.codex/skills` へ初回 seed する Docker 用デフォルト
+
+entrypoint は `docker/codex-home-defaults/` だけを `CODEX_HOME` に初回投入します。`~/AGENTS.md` は `~/.codex/AGENTS.md` への symlink として揃えます。`/app/.codex/skills` は自動複製しません。  
+既に `./.docker/codex-home` 側に存在するファイルは保持し、repo 更新で自動上書きはしません。
+
+デフォルトを再投入したい場合は、対象の `./.docker/codex-home` 側ファイルを削除してから container を再起動します。
 
 ## 環境変数
 


### PR DESCRIPTION
## Summary
- Docker 用の Codex defaults を `docker/codex-home-defaults/` に分離
- entrypoint で `CODEX_HOME` へ初回 seed し、既存 state は保持
- global rules の実体を `~/.codex/AGENTS.md` に寄せ、`~/AGENTS.md` は symlink に統一

## Testing
- `npm run check`
- `docker compose up -d --build`
- `docker compose exec app sh -lc 'echo CODEX_HOME=$CODEX_HOME; echo CODEX_WORKER_CWD=$CODEX_WORKER_CWD; test -L /root/AGENTS.md && echo home_agents_symlink=yes || echo home_agents_symlink=no; test -f /root/.codex/AGENTS.md && echo codex_home_agents=yes || echo codex_home_agents=no; test -f /root/.codex/skills/playwright-cli-docker/SKILL.md && echo default_skill=yes || echo default_skill=no; readlink /root/AGENTS.md'`
- isolated compose で `~/.codex/AGENTS.md` の保持と新規 default skill の追加 seed を確認
