### PR TITLE
Slack添付ファイル対応を拡張する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .env
+.env.*.local
 .docker/
 .playwright/
 .playwright-cli/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     chromium \
     gh \
     jq \
+    poppler-utils \
     ripgrep \
     sqlite3 \
     xvfb \

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ PORT=
 
 `SLACK_AGENT_CHAT_STATUS_ENABLED=true` にすると、進捗通知に `assistant.threads.setStatus` を使います。classic な DM スレッド返信を維持したい場合は、Slack App 側の `Agent or Assistant` は OFF にしてください。
 
-通常回答の completed メッセージは、送信直前に Markdown を Slack 向けテキストへ整形します。箇条書きは `* `、番号付きリストは `1. ` の行構造を保つようにしています。ローカル画像パス（`/tmp/...png` など）が含まれる場合は、本文から取り除いたうえで thread にファイル添付します。Slack で受け取った画像添付は bot token の `files:read` で download し、一時ファイルのパスを worker に渡します。approval と status は今回の変換対象外です。
+通常回答の completed メッセージは、送信直前に Markdown を Slack 向けテキストへ整形します。箇条書きは `* `、番号付きリストは `1. ` の行構造を保つようにしています。ローカル画像パス（`/tmp/...png` など）が含まれる場合は、本文から取り除いたうえで thread にファイル添付します。Slack で受け取った添付ファイルは bot token の `files:read` で download し、対応形式の画像・PDF・テキスト系ファイルは一時ファイルのパスを worker に渡します。未対応 MIME type やサイズ上限超過は thread に warning を返し、turn 後に一時ディレクトリを cleanup します。approval と status は今回の変換対象外です。
 
 DM では管理コマンドも使えます。Slack の slash command ではなく通常メッセージとして送ります。先頭の空白は任意です。
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ PORT=
 
 `SLACK_AGENT_CHAT_STATUS_ENABLED=true` にすると、進捗通知に `assistant.threads.setStatus` を使います。classic な DM スレッド返信を維持したい場合は、Slack App 側の `Agent or Assistant` は OFF にしてください。
 
-通常回答の completed メッセージは、送信直前に Markdown を Slack 向けテキストへ整形します。箇条書きは `* `、番号付きリストは `1. ` の行構造を保つようにしています。ローカル画像パス（`/tmp/...png` など）が含まれる場合は、本文から取り除いたうえで thread にファイル添付します。Slack で受け取った添付ファイルは bot token の `files:read` で download し、対応形式の画像・PDF・テキスト系ファイルは一時ファイルのパスを worker に渡します。未対応 MIME type やサイズ上限超過は thread に warning を返し、turn 後に一時ディレクトリを cleanup します。approval と status は今回の変換対象外です。
+通常回答の completed メッセージは、送信直前に Markdown を Slack 向けテキストへ整形します。箇条書きは `* `、番号付きリストは `1. ` の行構造を保つようにしています。ローカル画像パス（`/tmp/...png` など）が含まれる場合は、本文から取り除いたうえで thread にファイル添付します。Slack で受け取った添付ファイルは bot token の `files:read` で download し、対応形式の画像・PDF・テキスト系ファイルは一時ファイルのパスを worker に渡します。テキスト系と PDF は内容プレビューも worker 入力へ埋め込みます。未対応 MIME type やサイズ上限超過は thread に warning を返し、turn 後に一時ディレクトリを cleanup します。approval と status は今回の変換対象外です。
 
 DM では管理コマンドも使えます。Slack の slash command ではなく通常メッセージとして送ります。先頭の空白は任意です。
 

--- a/docker/codex-home-defaults/skills/playwright-cli-docker/SKILL.md
+++ b/docker/codex-home-defaults/skills/playwright-cli-docker/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: playwright-cli-docker
+description: Docker 内の `playwright-cli` 実行に限定した補助 skill。named session の利用、スクリーンショット再利用、container profile 前提の操作に絞る。
+---
+
 # playwright-cli-docker
 
 Docker 内の `playwright-cli` 実行に限定した補助 skill。

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,6 +23,19 @@ prune_dangling_skill_symlinks() {
   done < <(find "${skills_dir}" -type l -print0)
 }
 
+skill_has_yaml_frontmatter() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    return 1
+  fi
+
+  if [[ "$(head -n 1 "${path}")" != "---" ]]; then
+    return 1
+  fi
+
+  tail -n +2 "${path}" | grep -m 1 -x -- "---" >/dev/null
+}
+
 seed_file_if_missing() {
   local src="$1"
   local dest="$2"
@@ -58,6 +71,41 @@ seed_children_if_missing() {
   done < <(find "${src_dir}" -mindepth 1 -maxdepth 1 -print0)
 }
 
+repair_invalid_seeded_skills() {
+  local src_dir="$1"
+  local dest_dir="$2"
+  if [[ ! -d "${src_dir}" || ! -d "${dest_dir}" ]]; then
+    return
+  fi
+
+  while IFS= read -r -d '' src_path; do
+    local name
+    local dest_path
+    local src_skill
+    local dest_skill
+    name="$(basename "${src_path}")"
+    dest_path="${dest_dir}/${name}"
+    src_skill="${src_path}/SKILL.md"
+    dest_skill="${dest_path}/SKILL.md"
+
+    if [[ ! -d "${dest_path}" || ! -f "${src_skill}" || ! -f "${dest_skill}" ]]; then
+      continue
+    fi
+
+    if ! skill_has_yaml_frontmatter "${src_skill}"; then
+      continue
+    fi
+
+    if skill_has_yaml_frontmatter "${dest_skill}"; then
+      continue
+    fi
+
+    rm -rf "${dest_path}"
+    cp -R "${src_path}" "${dest_path}"
+    echo "repaired invalid skill seed: ${dest_path}" >&2
+  done < <(find "${src_dir}" -mindepth 1 -maxdepth 1 -type d -print0)
+}
+
 ensure_home_agents_link() {
   local codex_home="${CODEX_HOME:-/root/.codex}"
   local codex_home_agents="${codex_home}/AGENTS.md"
@@ -82,13 +130,14 @@ seed_codex_home_defaults() {
 
   seed_file_if_missing "${defaults_dir}/AGENTS.md" "${codex_home}/AGENTS.md"
   seed_children_if_missing "${defaults_dir}/skills" "${codex_home}/skills"
+  repair_invalid_seeded_skills "${defaults_dir}/skills" "${codex_home}/skills"
   ensure_home_agents_link
 }
 
 mkdir -p "${CODEX_HOME:-/root/.codex}"
 mkdir -p "${PLAYWRIGHT_AGENT_PROFILE_DIR:-/profiles/agent}"
 mkdir -p "$(dirname "${SQLITE_PATH:-/data/app.sqlite}")"
-mkdir -p /run/playwright
+mkdir -p "$(dirname "${PLAYWRIGHT_MCP_CONFIG:-/run/playwright/cli.config.json}")"
 
 require_env SLACK_BOT_TOKEN
 require_env SLACK_APP_TOKEN

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -100,9 +100,8 @@ repair_invalid_seeded_skills() {
       continue
     fi
 
-    rm -rf "${dest_path}"
-    cp -R "${src_path}" "${dest_path}"
-    echo "repaired invalid skill seed: ${dest_path}" >&2
+    cp "${src_skill}" "${dest_skill}"
+    echo "repaired invalid skill definition: ${dest_skill}" >&2
   done < <(find "${src_dir}" -mindepth 1 -maxdepth 1 -type d -print0)
 }
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,7 +33,7 @@ Docker では rules / skills を次の 2 層で分けます。
   - `~/.codex/AGENTS.md`, `~/.codex/skills` へ初回 seed する Docker 用デフォルト
 
 entrypoint は `docker/codex-home-defaults/` だけを `CODEX_HOME` に初回投入します。`~/AGENTS.md` は `~/.codex/AGENTS.md` への symlink として揃えます。`/app/.codex/skills` は自動複製しません。  
-既に `./.docker/codex-home` 側に存在するファイルは保持し、repo 更新で自動上書きはしません。
+既に `./.docker/codex-home` 側に存在するファイルは保持し、repo 更新で自動上書きはしません。ただし default 側は正常で、seed 済みの `SKILL.md` が壊れている場合だけは起動時に自動修復します。
 
 デフォルトを再投入したい場合は、対象の `./.docker/codex-home` 側ファイルを削除してから container を再起動します。
 

--- a/docs/slack-api-setup.md
+++ b/docs/slack-api-setup.md
@@ -56,7 +56,7 @@ Slack で「このアプリへのメッセージ送信はオフにされてい�
 - `chat:write`（Bot がスレッド返信し、AgentChat status 更新にも使う）
 - `im:history`（DM の `message.im` イベントを購読するため）
 - `files:write`（ローカル画像を thread に添付アップロードするため）
-- `files:read`（Slack で受け取った画像添付を download して worker に渡すため）
+- `files:read`（Slack で受け取った画像・PDF・テキスト系添付を download して worker に渡すため）
 
 補足:
 

--- a/src/gateway/bolt.ts
+++ b/src/gateway/bolt.ts
@@ -43,6 +43,7 @@ interface RawSlackMessageEvent {
     id?: string;
     name?: string;
     mimetype?: string;
+    size?: number;
     url_private?: string;
     url_private_download?: string;
   }>;
@@ -50,6 +51,14 @@ interface RawSlackMessageEvent {
 
 const debugSlackEvents = process.env.DEBUG_SLACK_EVENTS === 'true';
 const DOWNLOADABLE_IMAGE_MIME_PREFIX = 'image/';
+const MAX_DOWNLOADABLE_SLACK_FILE_BYTES = 10 * 1024 * 1024;
+const DOWNLOADABLE_TEXT_MIME_TYPES = new Set([
+  'application/json',
+  'application/pdf',
+  'application/xml',
+  'application/x-yaml',
+  'text/xml',
+]);
 
 export function createBoltGatewayRuntime(
   gateway: Gateway,
@@ -225,14 +234,16 @@ export async function buildSlackMessageEvent(
   }
 
   try {
-    const downloaded = await downloadSlackImageFiles(event.files, botToken);
+    const downloaded = await downloadSlackFiles(event.files, botToken);
     return {
       ...baseEvent,
-      text: appendDownloadedImagesToText(baseEvent.text, downloaded.files),
+      text: appendDownloadedFilesToText(baseEvent.text, downloaded.files),
+      attachment_warnings: downloaded.warnings.length > 0 ? downloaded.warnings : undefined,
+      downloaded_files_count: downloaded.files.length,
       temporary_directory: downloaded.directory,
     };
   } catch (error) {
-    logSlackImageDownloadError('build', event, error);
+    logSlackFileDownloadError('build', event, error);
     return baseEvent;
   }
 }
@@ -278,7 +289,7 @@ export function readApprovalPrompt(body: any, fallback?: string): string {
   return 'Approval required to continue.';
 }
 
-export function appendDownloadedImagesToText(
+export function appendDownloadedFilesToText(
   text: string,
   files: Array<{ path: string; name?: string; mimetype?: string }>,
 ): string {
@@ -291,43 +302,53 @@ export function appendDownloadedImagesToText(
     return `- ${label}${file.path}`;
   });
 
-  const attachmentSection = ['添付画像:', ...attachmentLines].join('\n');
+  const attachmentSection = ['添付ファイル:', ...attachmentLines].join('\n');
   return [text.trim(), attachmentSection].filter(Boolean).join('\n\n');
 }
 
-async function downloadSlackImageFiles(
+export const appendDownloadedImagesToText = appendDownloadedFilesToText;
+
+async function downloadSlackFiles(
   files: RawSlackMessageEvent['files'],
   botToken: string,
 ): Promise<{
   directory?: string;
   files: Array<{ path: string; name?: string; mimetype?: string }>;
+  warnings: string[];
 }> {
   if (!Array.isArray(files) || files.length === 0) {
-    return { files: [] };
+    return { files: [], warnings: [] };
   }
 
-  const imageFiles = files.filter((file) => isDownloadableImageFile(file));
-  if (imageFiles.length === 0) {
-    return { files: [] };
-  }
-
-  const directory = await mkdtemp(join(tmpdir(), 'codex-agent-slack-files-'));
+  let directory: string | undefined;
   const downloaded: Array<{ path: string; name?: string; mimetype?: string }> = [];
+  const warnings: string[] = [];
 
-  for (const file of imageFiles) {
+  for (const file of files) {
+    const rejectionReason = rejectSlackFileDownload(file);
+    if (rejectionReason) {
+      warnings.push(formatSlackAttachmentWarning(file, rejectionReason));
+      continue;
+    }
+
     try {
       const sourceUrl = file.url_private_download ?? file.url_private;
       if (!sourceUrl) {
+        warnings.push(formatSlackAttachmentWarning(file, 'ダウンロード URL が見つかりません。'));
         continue;
       }
 
+      directory ??= await mkdtemp(join(tmpdir(), 'codex-agent-slack-files-'));
       const response = await fetch(sourceUrl, {
         headers: {
           Authorization: `Bearer ${botToken}`,
         },
       });
       if (!response.ok) {
-        logSlackImageDownloadError('fetch', undefined, new Error(`Slack returned ${response.status}`), file);
+        logSlackFileDownloadError('fetch', undefined, new Error(`Slack returned ${response.status}`), file);
+        warnings.push(
+          formatSlackAttachmentWarning(file, `ダウンロードに失敗しました (HTTP ${response.status})。`),
+        );
         continue;
       }
 
@@ -341,20 +362,49 @@ async function downloadSlackImageFiles(
         mimetype: file.mimetype,
       });
     } catch (error) {
-      logSlackImageDownloadError('file', undefined, error, file);
+      logSlackFileDownloadError('file', undefined, error, file);
+      warnings.push(formatSlackAttachmentWarning(file, `ダウンロードに失敗しました (${String(error)})。`));
     }
   }
 
-  if (downloaded.length === 0) {
+  if (downloaded.length === 0 && directory) {
     await rm(directory, { recursive: true, force: true });
-    return { files: [] };
+    directory = undefined;
   }
 
-  return { directory, files: downloaded };
+  return { directory, files: downloaded, warnings };
 }
 
-function isDownloadableImageFile(file: NonNullable<RawSlackMessageEvent['files']>[number]): boolean {
-  return typeof file.mimetype === 'string' && file.mimetype.startsWith(DOWNLOADABLE_IMAGE_MIME_PREFIX);
+function rejectSlackFileDownload(file: NonNullable<RawSlackMessageEvent['files']>[number]): string | undefined {
+  if (typeof file.size === 'number' && file.size > MAX_DOWNLOADABLE_SLACK_FILE_BYTES) {
+    return `サイズ上限 ${formatBytes(MAX_DOWNLOADABLE_SLACK_FILE_BYTES)} を超えています (${formatBytes(file.size)})。`;
+  }
+
+  if (!isDownloadableSlackFile(file)) {
+    return `未対応の MIME type です (${file.mimetype ?? 'unknown'})。`;
+  }
+
+  return undefined;
+}
+
+function isDownloadableSlackFile(file: NonNullable<RawSlackMessageEvent['files']>[number]): boolean {
+  if (typeof file.mimetype !== 'string') {
+    return false;
+  }
+
+  return (
+    file.mimetype.startsWith(DOWNLOADABLE_IMAGE_MIME_PREFIX) ||
+    file.mimetype.startsWith('text/') ||
+    DOWNLOADABLE_TEXT_MIME_TYPES.has(file.mimetype)
+  );
+}
+
+function formatSlackAttachmentWarning(
+  file: NonNullable<RawSlackMessageEvent['files']>[number],
+  reason: string,
+): string {
+  const label = file.name ?? file.id ?? 'unknown';
+  return `- ${label}: ${reason}`;
 }
 
 function sanitizeDownloadedFileName(name?: string, mimetype?: string): string {
@@ -380,7 +430,30 @@ function mimeTypeToExtension(mimetype?: string): string {
   if (mimetype === 'image/webp') {
     return '.webp';
   }
+  if (mimetype === 'application/pdf') {
+    return '.pdf';
+  }
+  if (mimetype === 'application/json') {
+    return '.json';
+  }
+  if (mimetype === 'application/xml' || mimetype === 'text/xml') {
+    return '.xml';
+  }
+  if (mimetype === 'application/x-yaml') {
+    return '.yaml';
+  }
+  if (typeof mimetype === 'string' && mimetype.startsWith('text/')) {
+    return '.txt';
+  }
   return '';
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024 * 1024) {
+    return `${Math.round(value / 102.4) / 10} KB`;
+  }
+
+  return `${Math.round((value / (1024 * 1024)) * 10) / 10} MB`;
 }
 
 function logSlackEvent(type: string, event: RawSlackMessageEvent): void {
@@ -459,15 +532,15 @@ function logSlackMessageHandlingError(event: RawSlackMessageEvent, error: unknow
   );
 }
 
-function logSlackImageDownloadError(
+function logSlackFileDownloadError(
   stage: 'build' | 'fetch' | 'file',
   event: RawSlackMessageEvent | undefined,
   error: unknown,
-  file?: { id?: string; name?: string; mimetype?: string },
+  file?: { id?: string; name?: string; mimetype?: string; size?: number },
 ): void {
   // eslint-disable-next-line no-console
   console.error(
-    '[slack:image-download-error]',
+    '[slack:file-download-error]',
     JSON.stringify({
       stage,
       error: String(error),
@@ -477,6 +550,7 @@ function logSlackImageDownloadError(
       file_id: file?.id ?? null,
       file_name: file?.name ?? null,
       mimetype: file?.mimetype ?? null,
+      size: file?.size ?? null,
     }),
   );
 }

--- a/src/gateway/bolt.ts
+++ b/src/gateway/bolt.ts
@@ -1,6 +1,8 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
 import { App } from '@slack/bolt';
 import { Gateway, type SlackApprovalAction, type SlackMessageEvent, type SlackPublisher } from './gateway.js';
 
@@ -50,8 +52,11 @@ interface RawSlackMessageEvent {
 }
 
 const debugSlackEvents = process.env.DEBUG_SLACK_EVENTS === 'true';
+const execFileAsync = promisify(execFile);
 const DOWNLOADABLE_IMAGE_MIME_PREFIX = 'image/';
 const MAX_DOWNLOADABLE_SLACK_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_ATTACHMENT_PREVIEW_CHARS = 6000;
+const MAX_TEXT_ATTACHMENT_BYTES = 64 * 1024;
 const DOWNLOADABLE_TEXT_MIME_TYPES = new Set([
   'application/json',
   'application/pdf',
@@ -291,7 +296,7 @@ export function readApprovalPrompt(body: any, fallback?: string): string {
 
 export function appendDownloadedFilesToText(
   text: string,
-  files: Array<{ path: string; name?: string; mimetype?: string }>,
+  files: Array<{ path: string; name?: string; mimetype?: string; preview?: string }>,
 ): string {
   if (files.length === 0) {
     return text;
@@ -303,7 +308,16 @@ export function appendDownloadedFilesToText(
   });
 
   const attachmentSection = ['添付ファイル:', ...attachmentLines].join('\n');
-  return [text.trim(), attachmentSection].filter(Boolean).join('\n\n');
+  const previewLines = files
+    .filter((file) => file.preview)
+    .flatMap((file) => {
+      const title = `- ${file.name ?? basename(file.path)}`;
+      return [title, file.preview ?? ''];
+    });
+  const previewSection =
+    previewLines.length > 0 ? ['添付ファイル内容:', ...previewLines].join('\n') : '';
+
+  return [text.trim(), attachmentSection, previewSection].filter(Boolean).join('\n\n');
 }
 
 export const appendDownloadedImagesToText = appendDownloadedFilesToText;
@@ -313,7 +327,7 @@ async function downloadSlackFiles(
   botToken: string,
 ): Promise<{
   directory?: string;
-  files: Array<{ path: string; name?: string; mimetype?: string }>;
+  files: Array<{ path: string; name?: string; mimetype?: string; preview?: string }>;
   warnings: string[];
 }> {
   if (!Array.isArray(files) || files.length === 0) {
@@ -321,7 +335,7 @@ async function downloadSlackFiles(
   }
 
   let directory: string | undefined;
-  const downloaded: Array<{ path: string; name?: string; mimetype?: string }> = [];
+  const downloaded: Array<{ path: string; name?: string; mimetype?: string; preview?: string }> = [];
   const warnings: string[] = [];
 
   for (const file of files) {
@@ -356,10 +370,12 @@ async function downloadSlackFiles(
       const targetPath = join(directory, fileName);
       const bytes = new Uint8Array(await response.arrayBuffer());
       await writeFile(targetPath, bytes);
+      const preview = await extractSlackFilePreview(targetPath, file.mimetype);
       downloaded.push({
         path: targetPath,
         name: file.name,
         mimetype: file.mimetype,
+        preview,
       });
     } catch (error) {
       logSlackFileDownloadError('file', undefined, error, file);
@@ -405,6 +421,42 @@ function formatSlackAttachmentWarning(
 ): string {
   const label = file.name ?? file.id ?? 'unknown';
   return `- ${label}: ${reason}`;
+}
+
+async function extractSlackFilePreview(path: string, mimetype?: string): Promise<string | undefined> {
+  try {
+    if (mimetype === 'application/pdf') {
+      const { stdout } = await execFileAsync('pdftotext', ['-layout', path, '-'], {
+        maxBuffer: 1024 * 1024,
+      });
+      return normalizeAttachmentPreview(stdout);
+    }
+
+    if (
+      (typeof mimetype === 'string' && mimetype.startsWith('text/')) ||
+      (mimetype && DOWNLOADABLE_TEXT_MIME_TYPES.has(mimetype) && mimetype !== 'application/pdf')
+    ) {
+      const buffer = await readFile(path);
+      return normalizeAttachmentPreview(buffer.subarray(0, MAX_TEXT_ATTACHMENT_BYTES).toString('utf8'));
+    }
+  } catch (error) {
+    logSlackAttachmentPreviewError(path, mimetype, error);
+  }
+
+  return undefined;
+}
+
+function normalizeAttachmentPreview(value: string): string | undefined {
+  const trimmed = value.replace(/\u0000/g, '').trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (trimmed.length <= MAX_ATTACHMENT_PREVIEW_CHARS) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, MAX_ATTACHMENT_PREVIEW_CHARS)}\n...`;
 }
 
 function sanitizeDownloadedFileName(name?: string, mimetype?: string): string {
@@ -454,6 +506,18 @@ function formatBytes(value: number): string {
   }
 
   return `${Math.round((value / (1024 * 1024)) * 10) / 10} MB`;
+}
+
+function logSlackAttachmentPreviewError(path: string, mimetype: string | undefined, error: unknown): void {
+  // eslint-disable-next-line no-console
+  console.error(
+    '[slack:file-preview-error]',
+    JSON.stringify({
+      error: String(error),
+      path,
+      mimetype: mimetype ?? null,
+    }),
+  );
 }
 
 function logSlackEvent(type: string, event: RawSlackMessageEvent): void {

--- a/src/gateway/bolt.ts
+++ b/src/gateway/bolt.ts
@@ -238,6 +238,10 @@ export async function buildSlackMessageEvent(
     return null;
   }
 
+  if (!shouldDownloadSlackAttachments(baseEvent)) {
+    return baseEvent;
+  }
+
   try {
     const downloaded = await downloadSlackFiles(event.files, botToken);
     return {
@@ -366,7 +370,7 @@ async function downloadSlackFiles(
         continue;
       }
 
-      const fileName = sanitizeDownloadedFileName(file.name, file.mimetype);
+      const fileName = sanitizeDownloadedFileName(file.id, file.name, file.mimetype);
       const targetPath = join(directory, fileName);
       const bytes = new Uint8Array(await response.arrayBuffer());
       await writeFile(targetPath, bytes);
@@ -389,6 +393,10 @@ async function downloadSlackFiles(
   }
 
   return { directory, files: downloaded, warnings };
+}
+
+function shouldDownloadSlackAttachments(event: SlackMessageEvent): boolean {
+  return event.channel_type === 'im' && (!event.subtype || event.subtype === 'file_share');
 }
 
 function rejectSlackFileDownload(file: NonNullable<RawSlackMessageEvent['files']>[number]): string | undefined {
@@ -459,14 +467,18 @@ function normalizeAttachmentPreview(value: string): string | undefined {
   return `${trimmed.slice(0, MAX_ATTACHMENT_PREVIEW_CHARS)}\n...`;
 }
 
-function sanitizeDownloadedFileName(name?: string, mimetype?: string): string {
+function sanitizeDownloadedFileName(id?: string, name?: string, mimetype?: string): string {
   const baseName = (name && basename(name).replace(/[^a-zA-Z0-9._-]/g, '_')) || 'attachment';
+  const safeId = id ? id.replace(/[^a-zA-Z0-9._-]/g, '_') : undefined;
+  const suffix = safeId ? `-${safeId}` : '';
   if (extname(baseName)) {
-    return baseName;
+    const extension = extname(baseName);
+    const stem = baseName.slice(0, -extension.length) || 'attachment';
+    return `${stem}${suffix}${extension}`;
   }
 
   const fallbackExtension = mimeTypeToExtension(mimetype);
-  return `${baseName}${fallbackExtension}`;
+  return `${baseName}${suffix}${fallbackExtension}`;
 }
 
 function mimeTypeToExtension(mimetype?: string): string {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -64,6 +64,8 @@ export interface SlackApprovalAction {
 }
 
 export class Gateway implements GatewayNotifier {
+  private readonly pendingAttachmentDirectories = new Map<string, string>();
+
   public constructor(
     private readonly orchestrator: Orchestrator,
     private readonly publisher: SlackPublisher,
@@ -71,14 +73,21 @@ export class Gateway implements GatewayNotifier {
   ) {}
 
   public async handleMessageEvent(event: SlackMessageEvent): Promise<void> {
+    let rootThreadTs = event.ts;
+    let pendingAttachmentKey: string | undefined;
+    let previousPendingDirectory: string | undefined;
+    let nextSessionState: Session['state'] | undefined;
+
     try {
       if (event.channel_type !== 'im' || (event.subtype && event.subtype !== 'file_share')) {
         return;
       }
 
-      const rootThreadTs =
+      rootThreadTs =
         event.assistant_thread?.thread_ts ??
         (event.parent_user_id && event.thread_ts ? event.thread_ts : event.ts);
+      pendingAttachmentKey = this.toPendingAttachmentKey(event.team_id, event.channel_id, rootThreadTs);
+      previousPendingDirectory = this.pendingAttachmentDirectories.get(pendingAttachmentKey);
 
       if (event.attachment_warnings && event.attachment_warnings.length > 0) {
         await this.publisher.postThreadMessage({
@@ -114,7 +123,7 @@ export class Gateway implements GatewayNotifier {
           user_id: event.user_id,
           text: event.text,
         };
-        await this.orchestrator.startSession(input);
+        nextSessionState = (await this.orchestrator.startSession(input)).state;
         return;
       }
 
@@ -125,15 +134,25 @@ export class Gateway implements GatewayNotifier {
         user_id: event.user_id,
         text: event.text,
       };
-      await this.orchestrator.continueSession(input);
+      nextSessionState = (await this.orchestrator.continueSession(input)).state;
     } finally {
-      if (event.temporary_directory) {
-        await rm(event.temporary_directory, { recursive: true, force: true });
+      if (pendingAttachmentKey) {
+        await this.reconcilePendingAttachmentDirectory(
+          pendingAttachmentKey,
+          previousPendingDirectory,
+          event.temporary_directory,
+          nextSessionState,
+        );
       }
     }
   }
 
   public async handleApprovalAction(action: SlackApprovalAction): Promise<void> {
+    const pendingAttachmentKey = this.toPendingAttachmentKey(
+      action.team_id,
+      action.channel_id,
+      action.root_thread_ts,
+    );
     const input: ResolveApprovalInput = {
       channel_team_id: action.team_id,
       channel_id: action.channel_id,
@@ -142,7 +161,14 @@ export class Gateway implements GatewayNotifier {
       decision: action.decision,
     };
 
-    await this.orchestrator.resolveApproval(input);
+    const resolved = await this.orchestrator.resolveApproval(input);
+    if (resolved.state !== 'waiting_approval') {
+      const pendingDirectory = this.pendingAttachmentDirectories.get(pendingAttachmentKey);
+      this.pendingAttachmentDirectories.delete(pendingAttachmentKey);
+      if (pendingDirectory) {
+        await rm(pendingDirectory, { recursive: true, force: true });
+      }
+    }
   }
 
   public async notifyProgress(session: Session, message: string): Promise<void> {
@@ -244,6 +270,33 @@ export class Gateway implements GatewayNotifier {
       root_thread_ts: session.slack_root_thread_ts,
       text: `:warning: ${message}`,
     });
+  }
+
+  private toPendingAttachmentKey(teamId: string, channelId: string, rootThreadTs: string): string {
+    return `${teamId}:${channelId}:${rootThreadTs}`;
+  }
+
+  private async reconcilePendingAttachmentDirectory(
+    pendingAttachmentKey: string,
+    previousPendingDirectory: string | undefined,
+    currentTemporaryDirectory: string | undefined,
+    nextSessionState: Session['state'] | undefined,
+  ): Promise<void> {
+    if (nextSessionState === 'waiting_approval' && currentTemporaryDirectory) {
+      this.pendingAttachmentDirectories.set(pendingAttachmentKey, currentTemporaryDirectory);
+      if (previousPendingDirectory && previousPendingDirectory !== currentTemporaryDirectory) {
+        await rm(previousPendingDirectory, { recursive: true, force: true });
+      }
+      return;
+    }
+
+    this.pendingAttachmentDirectories.delete(pendingAttachmentKey);
+    const directories = new Set(
+      [previousPendingDirectory, currentTemporaryDirectory].filter((value): value is string => Boolean(value)),
+    );
+    for (const directory of directories) {
+      await rm(directory, { recursive: true, force: true });
+    }
   }
 }
 export {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -49,6 +49,8 @@ export interface SlackMessageEvent {
   };
   channel_type: 'im' | 'channel' | 'group' | 'mpim';
   subtype?: string;
+  attachment_warnings?: string[];
+  downloaded_files_count?: number;
   temporary_directory?: string;
 }
 
@@ -77,6 +79,21 @@ export class Gateway implements GatewayNotifier {
       const rootThreadTs =
         event.assistant_thread?.thread_ts ??
         (event.parent_user_id && event.thread_ts ? event.thread_ts : event.ts);
+
+      if (event.attachment_warnings && event.attachment_warnings.length > 0) {
+        await this.publisher.postThreadMessage({
+          channel_id: event.channel_id,
+          root_thread_ts: rootThreadTs,
+          text: [
+            ':warning: 次の添付ファイルは worker に渡していません。',
+            ...event.attachment_warnings,
+          ].join('\n'),
+        });
+      }
+
+      if (!event.text.trim() && !event.downloaded_files_count && event.attachment_warnings?.length) {
+        return;
+      }
 
       const adminCommand = parseAdminCommand(event.text);
       if (adminCommand && this.adminCommands) {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -143,6 +143,8 @@ export class Gateway implements GatewayNotifier {
           event.temporary_directory,
           nextSessionState,
         );
+      } else if (event.temporary_directory) {
+        await rm(event.temporary_directory, { recursive: true, force: true });
       }
     }
   }

--- a/tests/specs/docker/codex-home-defaults.test.ts
+++ b/tests/specs/docker/codex-home-defaults.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+test('docker entrypoint repairs an invalid seeded skill when the default skill has YAML frontmatter', async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'codex-agent-docker-defaults-'));
+
+  try {
+    const defaultsDir = join(tempDir, 'defaults');
+    const homeDir = join(tempDir, 'home');
+    const codexHome = join(tempDir, 'codex-home');
+    const dataDir = join(tempDir, 'data');
+    const runDir = join(tempDir, 'run');
+    const profilesDir = join(tempDir, 'profiles');
+    const seededSkillDir = join(defaultsDir, 'skills', 'playwright-cli-docker');
+    const installedSkillDir = join(codexHome, 'skills', 'playwright-cli-docker');
+
+    mkdirSync(seededSkillDir, { recursive: true });
+    mkdirSync(installedSkillDir, { recursive: true });
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(runDir, { recursive: true });
+    mkdirSync(profilesDir, { recursive: true });
+
+    writeFileSync(join(defaultsDir, 'AGENTS.md'), '# AGENTS\n');
+    writeFileSync(
+      join(seededSkillDir, 'SKILL.md'),
+      ['---', 'name: playwright-cli-docker', 'description: test skill', '---', '', '# valid'].join('\n'),
+    );
+    writeFileSync(join(installedSkillDir, 'SKILL.md'), '# broken skill');
+
+    await execFileAsync('bash', ['docker/entrypoint.sh', 'true'], {
+      cwd: '/Users/yuya/dev/codex-agent',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        CODEX_HOME: codexHome,
+        CODEX_HOME_DEFAULTS_DIR: defaultsDir,
+        PLAYWRIGHT_AGENT_PROFILE_DIR: profilesDir,
+        PLAYWRIGHT_MCP_CONFIG: join(runDir, 'playwright.json'),
+        SQLITE_PATH: join(dataDir, 'app.sqlite'),
+        SLACK_BOT_TOKEN: 'xoxb-test',
+        SLACK_APP_TOKEN: 'xapp-test',
+      },
+    });
+
+    const repairedSkill = readFileSync(join(installedSkillDir, 'SKILL.md'), 'utf8');
+    assert.match(repairedSkill, /^---$/m);
+    assert.match(repairedSkill, /^name: playwright-cli-docker$/m);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/specs/docker/codex-home-defaults.test.ts
+++ b/tests/specs/docker/codex-home-defaults.test.ts
@@ -34,6 +34,7 @@ test('docker entrypoint repairs an invalid seeded skill when the default skill h
       ['---', 'name: playwright-cli-docker', 'description: test skill', '---', '', '# valid'].join('\n'),
     );
     writeFileSync(join(installedSkillDir, 'SKILL.md'), '# broken skill');
+    writeFileSync(join(installedSkillDir, 'notes.txt'), 'keep me');
 
     await execFileAsync('bash', ['docker/entrypoint.sh', 'true'], {
       cwd: '/Users/yuya/dev/codex-agent',
@@ -53,6 +54,7 @@ test('docker entrypoint repairs an invalid seeded skill when the default skill h
     const repairedSkill = readFileSync(join(installedSkillDir, 'SKILL.md'), 'utf8');
     assert.match(repairedSkill, /^---$/m);
     assert.match(repairedSkill, /^name: playwright-cli-docker$/m);
+    assert.equal(readFileSync(join(installedSkillDir, 'notes.txt'), 'utf8'), 'keep me');
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tests/specs/gateway/presentation.test.ts
+++ b/tests/specs/gateway/presentation.test.ts
@@ -172,3 +172,82 @@ test('gateway routing accepts file_share events and always cleans up downloaded 
   assert.deepEqual(calls, ['start']);
   assert.equal(existsSync(tempPath), false);
 });
+
+test('gateway routing posts attachment warnings and skips worker execution when no actionable input remains', async () => {
+  const posted: Array<{ text: string }> = [];
+  const calls: string[] = [];
+  const gateway = new Gateway(
+    {
+      startSession: async () => {
+        calls.push('start');
+        return createSession();
+      },
+      continueSession: async () => {
+        calls.push('continue');
+        return createSession();
+      },
+    } as any,
+    {
+      postThreadMessage: async (input) => {
+        posted.push({ text: input.text });
+      },
+      uploadThreadFiles: async () => {},
+      setThreadStatus: async () => {},
+    },
+  );
+
+  await gateway.handleMessageEvent({
+    team_id: 'T1',
+    channel_id: 'D1',
+    user_id: 'U1',
+    text: '',
+    ts: '100.1',
+    channel_type: 'im',
+    attachment_warnings: ['- archive.zip: 未対応の MIME type です (application/zip)。'],
+    downloaded_files_count: 0,
+  });
+
+  assert.deepEqual(calls, []);
+  assert.equal(posted.length, 1);
+  assert.match(posted[0]?.text ?? '', /worker に渡していません/u);
+  assert.match(posted[0]?.text ?? '', /archive\.zip/u);
+});
+
+test('gateway routing posts attachment warnings and still continues when supported files were downloaded', async () => {
+  const posted: Array<{ text: string }> = [];
+  const calls: string[] = [];
+  const gateway = new Gateway(
+    {
+      startSession: async () => {
+        calls.push('start');
+        return createSession();
+      },
+      continueSession: async () => {
+        calls.push('continue');
+        return createSession();
+      },
+    } as any,
+    {
+      postThreadMessage: async (input) => {
+        posted.push({ text: input.text });
+      },
+      uploadThreadFiles: async () => {},
+      setThreadStatus: async () => {},
+    },
+  );
+
+  await gateway.handleMessageEvent({
+    team_id: 'T1',
+    channel_id: 'D1',
+    user_id: 'U1',
+    text: ['本文', '', '添付ファイル:', '- spec.pdf: /tmp/spec.pdf'].join('\n'),
+    ts: '100.1',
+    channel_type: 'im',
+    attachment_warnings: ['- archive.zip: 未対応の MIME type です (application/zip)。'],
+    downloaded_files_count: 1,
+  });
+
+  assert.deepEqual(calls, ['start']);
+  assert.equal(posted.length, 1);
+  assert.match(posted[0]?.text ?? '', /archive\.zip/u);
+});

--- a/tests/specs/gateway/presentation.test.ts
+++ b/tests/specs/gateway/presentation.test.ts
@@ -173,6 +173,35 @@ test('gateway routing accepts file_share events and always cleans up downloaded 
   assert.equal(existsSync(tempPath), false);
 });
 
+test('gateway routing cleans up temporary files even for ignored non-DM events', async () => {
+  const tempPath = join(tmpdir(), `codex-agent-gateway-ignored-${Date.now()}`);
+  mkdirSync(tempPath, { recursive: true });
+
+  const gateway = new Gateway(
+    {
+      startSession: async () => createSession(),
+      continueSession: async () => createSession(),
+    } as any,
+    {
+      postThreadMessage: async () => {},
+      uploadThreadFiles: async () => {},
+      setThreadStatus: async () => {},
+    },
+  );
+
+  await gateway.handleMessageEvent({
+    team_id: 'T1',
+    channel_id: 'C1',
+    user_id: 'U1',
+    text: 'ignored',
+    ts: '100.1',
+    channel_type: 'channel',
+    temporary_directory: tempPath,
+  });
+
+  assert.equal(existsSync(tempPath), false);
+});
+
 test('gateway routing posts attachment warnings and skips worker execution when no actionable input remains', async () => {
   const posted: Array<{ text: string }> = [];
   const calls: string[] = [];

--- a/tests/specs/gateway/presentation.test.ts
+++ b/tests/specs/gateway/presentation.test.ts
@@ -251,3 +251,51 @@ test('gateway routing posts attachment warnings and still continues when support
   assert.equal(posted.length, 1);
   assert.match(posted[0]?.text ?? '', /archive\.zip/u);
 });
+
+test('gateway routing keeps attachment files until approval is resolved', async () => {
+  const tempPath = join(tmpdir(), `codex-agent-gateway-approval-${Date.now()}`);
+  mkdirSync(tempPath, { recursive: true });
+
+  const gateway = new Gateway(
+    {
+      startSession: async () => ({
+        ...createSession(),
+        state: 'waiting_approval' as const,
+        pending_approval_id: 'approval-1',
+      }),
+      continueSession: async () => createSession(),
+      resolveApproval: async () => ({
+        ...createSession(),
+        state: 'idle' as const,
+        pending_approval_id: null,
+      }),
+    } as any,
+    {
+      postThreadMessage: async () => {},
+      uploadThreadFiles: async () => {},
+      setThreadStatus: async () => {},
+    },
+  );
+
+  await gateway.handleMessageEvent({
+    team_id: 'T1',
+    channel_id: 'D1',
+    user_id: 'U1',
+    text: '添付を確認して',
+    ts: '100.1',
+    channel_type: 'im',
+    temporary_directory: tempPath,
+  });
+
+  assert.equal(existsSync(tempPath), true);
+
+  await gateway.handleApprovalAction({
+    team_id: 'T1',
+    channel_id: 'D1',
+    root_thread_ts: '100.1',
+    approval_id: 'approval-1',
+    decision: 'approve',
+  });
+
+  assert.equal(existsSync(tempPath), false);
+});

--- a/tests/specs/gateway/slack-message-event.test.ts
+++ b/tests/specs/gateway/slack-message-event.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { rm } from 'node:fs/promises';
-import { appendDownloadedImagesToText, buildSlackMessageEvent, toSlackMessageEvent } from '../../../src/gateway/bolt.js';
+import { appendDownloadedFilesToText, buildSlackMessageEvent, toSlackMessageEvent } from '../../../src/gateway/bolt.js';
 
 test('Slack message event mapping turns threaded DM payloads into internal message events', () => {
   assert.deepEqual(
@@ -112,23 +112,30 @@ test('Slack message event mapping can fill team_id from the outer event envelope
     assistant_thread: undefined,
     channel_type: 'im',
     subtype: undefined,
+    attachment_warnings: undefined,
+    downloaded_files_count: 0,
     temporary_directory: undefined,
   });
 });
 
-test('Slack message event mapping appends downloaded image paths as an attachment section', () => {
+test('Slack message event mapping appends downloaded file paths as an attachment section', () => {
   assert.equal(
-    appendDownloadedImagesToText('本文', [
+    appendDownloadedFilesToText('本文', [
       { path: '/tmp/weather.png', name: 'weather.png', mimetype: 'image/png' },
     ]),
-    ['本文', '', '添付画像:', '- weather.png: /tmp/weather.png'].join('\n'),
+    ['本文', '', '添付ファイル:', '- weather.png: /tmp/weather.png'].join('\n'),
   );
 });
 
-test('Slack message event mapping falls back to the base text when image download throws', async () => {
+test('Slack message event mapping downloads PDF and text attachments to the temporary directory', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => {
-    throw new Error('network down');
+    return new Response('file-bytes', {
+      status: 200,
+      headers: {
+        'content-type': 'application/octet-stream',
+      },
+    });
   }) as typeof fetch;
 
   try {
@@ -136,38 +143,74 @@ test('Slack message event mapping falls back to the base text when image downloa
       team: 'T1',
       channel: 'D1',
       user: 'U1',
-      text: 'この画像見える？',
+      text: 'この添付を見て',
       ts: '100.2',
       channel_type: 'im',
       files: [
         {
           id: 'F1',
-          name: 'image.png',
-          mimetype: 'image/png',
-          url_private_download: 'https://files.example/image.png',
+          name: 'spec.pdf',
+          mimetype: 'application/pdf',
+          url_private_download: 'https://files.example/spec.pdf',
+        },
+        {
+          id: 'F2',
+          name: 'notes.txt',
+          mimetype: 'text/plain',
+          url_private_download: 'https://files.example/notes.txt',
         },
       ],
     }, 'xoxb-test');
 
-    assert.deepEqual(event, {
-      team_id: 'T1',
-      channel_id: 'D1',
-      user_id: 'U1',
-      text: 'この画像見える？',
-      ts: '100.2',
-      thread_ts: undefined,
-      parent_user_id: undefined,
-      assistant_thread: undefined,
-      channel_type: 'im',
-      subtype: undefined,
-      temporary_directory: undefined,
-    });
+    assert.equal(event?.text.includes('添付ファイル:'), true);
+    assert.equal(event?.text.includes('spec.pdf'), true);
+    assert.equal(event?.text.includes('notes.txt'), true);
+    assert.equal(event?.attachment_warnings, undefined);
+    assert.equal(event?.downloaded_files_count, 2);
+    assert.ok(event?.temporary_directory);
+    await rm(event?.temporary_directory ?? '', { recursive: true, force: true });
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test('Slack message event mapping continues when one attached image download fails', async () => {
+test('Slack message event mapping returns attachment warnings for unsupported and oversized files', async () => {
+  const event = await buildSlackMessageEvent({
+    team: 'T1',
+    channel: 'D1',
+    user: 'U1',
+    text: '',
+    ts: '100.2',
+    channel_type: 'im',
+    files: [
+      {
+        id: 'F1',
+        name: 'archive.zip',
+        mimetype: 'application/zip',
+        size: 1024,
+        url_private_download: 'https://files.example/archive.zip',
+      },
+      {
+        id: 'F2',
+        name: 'big.pdf',
+        mimetype: 'application/pdf',
+        size: 11 * 1024 * 1024,
+        url_private_download: 'https://files.example/big.pdf',
+      },
+    ],
+  }, 'xoxb-test');
+
+  assert.equal(event?.text, '');
+  assert.equal(event?.downloaded_files_count, 0);
+  assert.equal(event?.temporary_directory, undefined);
+  assert.equal(event?.attachment_warnings?.length, 2);
+  assert.match(event?.attachment_warnings?.[0] ?? '', /archive\.zip/u);
+  assert.match(event?.attachment_warnings?.[0] ?? '', /未対応/u);
+  assert.match(event?.attachment_warnings?.[1] ?? '', /big\.pdf/u);
+  assert.match(event?.attachment_warnings?.[1] ?? '', /サイズ上限/u);
+});
+
+test('Slack message event mapping continues when one attached file download fails', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = String(input);
@@ -209,7 +252,9 @@ test('Slack message event mapping continues when one attached image download fai
 
     assert.equal(event?.text.includes('good.png'), true);
     assert.equal(event?.text.includes('bad.png'), false);
-    assert.match(event?.text ?? '', /添付画像:/u);
+    assert.match(event?.text ?? '', /添付ファイル:/u);
+    assert.equal(event?.attachment_warnings?.length, 1);
+    assert.match(event?.attachment_warnings?.[0] ?? '', /bad\.png/u);
     assert.ok(event?.temporary_directory);
     await rm(event?.temporary_directory ?? '', { recursive: true, force: true });
   } finally {

--- a/tests/specs/gateway/slack-message-event.test.ts
+++ b/tests/specs/gateway/slack-message-event.test.ts
@@ -188,6 +188,84 @@ test('Slack message event mapping downloads PDF and text attachments to the temp
   }
 });
 
+test('Slack message event mapping does not download attachments for non-DM events', async () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    return new Response('file-bytes', { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const event = await buildSlackMessageEvent({
+      team: 'T1',
+      channel: 'C1',
+      user: 'U1',
+      text: 'channel message',
+      ts: '100.2',
+      channel_type: 'channel',
+      files: [
+        {
+          id: 'F1',
+          name: 'spec.pdf',
+          mimetype: 'application/pdf',
+          url_private_download: 'https://files.example/spec.pdf',
+        },
+      ],
+    }, 'xoxb-test');
+
+    assert.equal(fetchCalls, 0);
+    assert.equal(event?.temporary_directory, undefined);
+    assert.equal(event?.downloaded_files_count, undefined);
+    assert.equal(event?.text, 'channel message');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('Slack message event mapping stores same-name attachments under unique paths', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    return new Response('same-name', {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+      },
+    });
+  }) as typeof fetch;
+
+  try {
+    const event = await buildSlackMessageEvent({
+      team: 'T1',
+      channel: 'D1',
+      user: 'U1',
+      text: '確認して',
+      ts: '100.2',
+      channel_type: 'im',
+      files: [
+        {
+          id: 'F1',
+          name: 'same.txt',
+          mimetype: 'text/plain',
+          url_private_download: 'https://files.example/1',
+        },
+        {
+          id: 'F2',
+          name: 'same.txt',
+          mimetype: 'text/plain',
+          url_private_download: 'https://files.example/2',
+        },
+      ],
+    }, 'xoxb-test');
+
+    assert.match(event?.text ?? '', /same-F1\.txt/u);
+    assert.match(event?.text ?? '', /same-F2\.txt/u);
+    await rm(event?.temporary_directory ?? '', { recursive: true, force: true });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('Slack message event mapping includes text file previews when downloadable text is attached', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => {

--- a/tests/specs/gateway/slack-message-event.test.ts
+++ b/tests/specs/gateway/slack-message-event.test.ts
@@ -127,6 +127,20 @@ test('Slack message event mapping appends downloaded file paths as an attachment
   );
 });
 
+test('Slack message event mapping appends text attachment previews to the message', () => {
+  assert.equal(
+    appendDownloadedFilesToText('本文', [
+      {
+        path: '/tmp/notes.txt',
+        name: 'notes.txt',
+        mimetype: 'text/plain',
+        preview: '1行目\n2行目',
+      },
+    ]),
+    ['本文', '', '添付ファイル:', '- notes.txt: /tmp/notes.txt', '', '添付ファイル内容:', '- notes.txt', '1行目\n2行目'].join('\n'),
+  );
+});
+
 test('Slack message event mapping downloads PDF and text attachments to the temporary directory', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => {
@@ -168,6 +182,43 @@ test('Slack message event mapping downloads PDF and text attachments to the temp
     assert.equal(event?.attachment_warnings, undefined);
     assert.equal(event?.downloaded_files_count, 2);
     assert.ok(event?.temporary_directory);
+    await rm(event?.temporary_directory ?? '', { recursive: true, force: true });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('Slack message event mapping includes text file previews when downloadable text is attached', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    return new Response('申請期限は4月1日です。', {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+      },
+    });
+  }) as typeof fetch;
+
+  try {
+    const event = await buildSlackMessageEvent({
+      team: 'T1',
+      channel: 'D1',
+      user: 'U1',
+      text: '確認して',
+      ts: '100.2',
+      channel_type: 'im',
+      files: [
+        {
+          id: 'F1',
+          name: 'notes.txt',
+          mimetype: 'text/plain',
+          url_private_download: 'https://files.example/notes.txt',
+        },
+      ],
+    }, 'xoxb-test');
+
+    assert.match(event?.text ?? '', /添付ファイル内容:/u);
+    assert.match(event?.text ?? '', /申請期限は4月1日です。/u);
     await rm(event?.temporary_directory ?? '', { recursive: true, force: true });
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- Slack DM の添付処理を画像専用から PDF/テキスト系まで拡張
- 未対応 MIME やサイズ超過は warning を返し、approval またぎの一時ファイル保持を修正
- Docker 用 skill seed と PDF 抽出環境を整備

## Testing
- npm run check
- npm test

## Related
- Closes #3
