### PR TITLE
Docker 実行基盤を local/remote compose に分割

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export SLACK_APP_TOKEN='xapp-...'
 - [Spec](./docs/spec.md)
 - [Slack API 設定ガイド](./docs/slack-api-setup.md)
 - [Docker 運用ガイド](./docs/docker.md)
+- [Remote Deploy Guide](./docs/deploy-remote.md)
 - [Archive](./docs/archive/)
 
 必要な権限の要点:
@@ -94,28 +95,55 @@ npm start
 
 Slack token などは外部環境変数から渡します。
 
-`.env.example` を `.env` にコピーして使えます。
+ローカル起動では `compose.yaml` と `compose.override.yaml` が自動で使われます。`.env.example` を `.env` にコピーして使えます。
 
 ```bash
 docker compose up -d --build
 docker compose exec app codex login --device-auth
 ```
 
-Docker では次を使います。
+ローカル Docker では次を使います。
 
 - Codex 認証: `./.docker/codex-home`
 - Playwright profile: `./.docker/playwright-agent-profile`
 - SQLite: `./.docker/data/app.sqlite`
 - app / worker の作業ディレクトリ: `/app`
 
-Docker 内の rules/skills は 2 層です。
+remote Docker host では `compose.server.yaml` を追加指定します。
+
+```bash
+deploy/server/build.sh
+deploy/server/up.sh
+```
+
+registry image を使う場合は `deploy/server/build.sh` の代わりに `deploy/server/pull.sh` を使います。
+
+補助スクリプトを使わない場合:
+
+```bash
+docker compose --env-file /etc/codex-agent/app.env \
+  -f compose.yaml \
+  -f compose.server.yaml \
+  up -d
+```
+
+remote では次を使います。
+
+- Compose env file: `/etc/codex-agent/app.env`
+- 永続データ root: `/srv/codex-agent`
+- Codex 認証: `/srv/codex-agent/codex-home`
+- Playwright profile: `/srv/codex-agent/playwright-agent-profile`
+- SQLite: `/srv/codex-agent/data/app.sqlite`
+- `APP_IMAGE=codex-agent:local` の場合は host build、pullable image を指定した場合は pull 運用
+
+Docker 内の rules/skills は local / remote 共通で 2 層です。
 
 - project local: `/app/AGENTS.md`, `/app/.codex/skills`
 - Docker 用 `CODEX_HOME` defaults: `docker/codex-home-defaults/`
 
 container 起動時は `docker/codex-home-defaults/` だけを `~/.codex` に初回 seed します。global rules の実体は `~/.codex/AGENTS.md` で、`~/AGENTS.md` はその symlink として扱います。`/app/.codex/skills` をそのまま複製はしません。既存の `CODEX_HOME` 側ファイルは保持され、repo 更新で自動上書きはしません。
 
-詳細は [docs/docker.md](./docs/docker.md) を参照してください。
+詳細は [docs/docker.md](./docs/docker.md) と [docs/deploy-remote.md](./docs/deploy-remote.md) を参照してください。
 
 開発時:
 
@@ -126,7 +154,8 @@ npm run dev
 補足:
 
 - アプリ本体は環境変数をそのまま読みます
-- Docker Compose は `.env` を読めますが、ローカル実行時に `.env` を自動ロードはしません
+- local では `.env` と `compose.override.yaml` が自動で読まれます
+- remote では `--env-file /etc/codex-agent/app.env -f compose.yaml -f compose.server.yaml` を明示します
 - 起動時に `CODEX_HOME` の値が worker プロセスにも渡されます
 - Docker は host repo を bind mount しないので、コード変更反映には再 build が必要です
 
@@ -135,6 +164,7 @@ npm run dev
 ```bash
 SLACK_BOT_TOKEN=xoxb-...
 SLACK_APP_TOKEN=xapp-...
+APP_IMAGE=codex-agent:local
 DEBUG_SLACK_EVENTS=false
 DEBUG_WORKER_EVENTS=false
 DEBUG_WORKER_EVENT_DELTAS=false
@@ -147,6 +177,8 @@ SQLITE_PATH=./data/app.sqlite
 SLACK_AGENT_CHAT_STATUS_ENABLED=false
 PORT=
 ```
+
+remote 用テンプレートは `deploy/env/server.env.example` を使います。`HOST_STATE_ROOT` は remote 専用 compose 変数で、既定値は `/srv/codex-agent` です。
 
 `SLACK_AGENT_CHAT_STATUS_ENABLED=true` にすると、進捗通知に `assistant.threads.setStatus` を使います。classic な DM スレッド返信を維持したい場合は、Slack App 側の `Agent or Assistant` は OFF にしてください。
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,0 +1,11 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./.docker/codex-home:/root/.codex
+      - ./.docker/playwright-agent-profile:/profiles/agent
+      - ./.docker/data:/data
+    stdin_open: true
+    tty: true

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -1,0 +1,7 @@
+services:
+  app:
+    restart: unless-stopped
+    volumes:
+      - ${HOST_STATE_ROOT:-/srv/codex-agent}/codex-home:/root/.codex
+      - ${HOST_STATE_ROOT:-/srv/codex-agent}/playwright-agent-profile:/profiles/agent
+      - ${HOST_STATE_ROOT:-/srv/codex-agent}/data:/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,9 @@
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ${APP_IMAGE:-codex-agent:local}
     init: true
     ipc: host
+    command: ["npm", "start"]
     environment:
       SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:?SLACK_BOT_TOKEN is required}
       SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:?SLACK_APP_TOKEN is required}
@@ -21,9 +20,3 @@ services:
       PORT: ${PORT:-}
       PLAYWRIGHT_AGENT_PROFILE_DIR: ${PLAYWRIGHT_AGENT_PROFILE_DIR:-/profiles/agent}
       PLAYWRIGHT_MCP_CONFIG: ${PLAYWRIGHT_MCP_CONFIG:-/run/playwright/cli.config.json}
-    volumes:
-      - ./.docker/codex-home:/root/.codex
-      - ./.docker/playwright-agent-profile:/profiles/agent
-      - ./.docker/data:/data
-    stdin_open: true
-    tty: true

--- a/deploy/env/server.env.example
+++ b/deploy/env/server.env.example
@@ -1,14 +1,17 @@
+# Use a pullable registry image here, or keep codex-agent:local and run deploy/server/up.sh --build on the host.
+APP_IMAGE=codex-agent:local
+HOST_STATE_ROOT=/srv/codex-agent
+
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_APP_TOKEN=xapp-your-app-token
 
 # Optional
-# APP_IMAGE=codex-agent:local
 SLACK_AGENT_CHAT_STATUS_ENABLED=false
 DEBUG_SLACK_EVENTS=false
 DEBUG_WORKER_EVENTS=false
 DEBUG_WORKER_EVENT_DELTAS=false
 # WORKER_STREAM_EVENT_TIMEOUT_MS=300000
-# PORT=3000
+# PORT=
 # CODEX_HOME=/root/.codex
 # CODEX_WORKER_COMMAND=codex
 # CODEX_WORKER_ARGS=app-server

--- a/deploy/env/server.env.example
+++ b/deploy/env/server.env.example
@@ -1,4 +1,4 @@
-# Use a pullable registry image here, or keep codex-agent:local and run deploy/server/up.sh --build on the host.
+# Use a pullable registry image here, or keep codex-agent:local and run deploy/server/build.sh on the host.
 APP_IMAGE=codex-agent:local
 HOST_STATE_ROOT=/srv/codex-agent
 

--- a/deploy/server/bootstrap.sh
+++ b/deploy/server/bootstrap.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+host_state_root="${HOST_STATE_ROOT:-/srv/codex-agent}"
+app_env_path="${APP_ENV_PATH:-/etc/codex-agent/app.env}"
+
+mkdir -p "${host_state_root}/codex-home"
+mkdir -p "${host_state_root}/playwright-agent-profile"
+mkdir -p "${host_state_root}/data"
+
+cat <<EOF
+Created remote state directories under:
+  ${host_state_root}/codex-home
+  ${host_state_root}/playwright-agent-profile
+  ${host_state_root}/data
+
+Next steps:
+  1. Copy ${repo_root}/deploy/env/server.env.example to ${app_env_path}
+  2. Set SLACK_BOT_TOKEN and SLACK_APP_TOKEN in ${app_env_path}
+  3. If APP_IMAGE stays codex-agent:local, run ${repo_root}/deploy/server/up.sh --build
+  4. If APP_IMAGE points to a registry image, run ${repo_root}/deploy/server/up.sh
+  5. Run ${repo_root}/deploy/server/login-codex.sh for the initial Codex login
+EOF

--- a/deploy/server/bootstrap.sh
+++ b/deploy/server/bootstrap.sh
@@ -19,7 +19,7 @@ Created remote state directories under:
 Next steps:
   1. Copy ${repo_root}/deploy/env/server.env.example to ${app_env_path}
   2. Set SLACK_BOT_TOKEN and SLACK_APP_TOKEN in ${app_env_path}
-  3. If APP_IMAGE stays codex-agent:local, run ${repo_root}/deploy/server/up.sh --build
-  4. If APP_IMAGE points to a registry image, run ${repo_root}/deploy/server/up.sh
+  3. If APP_IMAGE stays codex-agent:local, run ${repo_root}/deploy/server/build.sh
+  4. If APP_IMAGE points to a registry image, run ${repo_root}/deploy/server/pull.sh
   5. Run ${repo_root}/deploy/server/login-codex.sh for the initial Codex login
 EOF

--- a/deploy/server/build.sh
+++ b/deploy/server/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+app_env_path="${APP_ENV_PATH:-/etc/codex-agent/app.env}"
+
+if [[ -z "${APP_IMAGE:-}" && -f "${app_env_path}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${app_env_path}"
+  set +a
+fi
+
+app_image="${APP_IMAGE:-codex-agent:local}"
+
+cd "${repo_root}"
+
+exec docker build -t "${app_image}" .

--- a/deploy/server/login-codex.sh
+++ b/deploy/server/login-codex.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+app_env_path="${APP_ENV_PATH:-/etc/codex-agent/app.env}"
+
+cd "${repo_root}"
+
+exec docker compose \
+  --env-file "${app_env_path}" \
+  -f compose.yaml \
+  -f compose.server.yaml \
+  exec app codex login --device-auth "$@"

--- a/deploy/server/logs.sh
+++ b/deploy/server/logs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+app_env_path="${APP_ENV_PATH:-/etc/codex-agent/app.env}"
+
+cd "${repo_root}"
+
+exec docker compose \
+  --env-file "${app_env_path}" \
+  -f compose.yaml \
+  -f compose.server.yaml \
+  logs -f app "$@"

--- a/deploy/server/pull.sh
+++ b/deploy/server/pull.sh
@@ -10,6 +10,16 @@ if [[ -z "${APP_IMAGE:-}" && -f "${app_env_path}" ]]; then
   set +a
 fi
 
-app_image="${APP_IMAGE:-codex-agent:local}"
+app_image="${APP_IMAGE:-}"
+if [[ -z "${app_image}" ]]; then
+  echo "APP_IMAGE is required for pull.sh" >&2
+  echo "Set APP_IMAGE in ${app_env_path} or export it before running this script." >&2
+  exit 1
+fi
+
+if [[ "${app_image}" == "codex-agent:local" ]]; then
+  echo "APP_IMAGE=${app_image} is a local build tag. Use deploy/server/build.sh instead." >&2
+  exit 1
+fi
 
 exec docker pull "${app_image}"

--- a/deploy/server/pull.sh
+++ b/deploy/server/pull.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_env_path="${APP_ENV_PATH:-/etc/codex-agent/app.env}"
+
+if [[ -z "${APP_IMAGE:-}" && -f "${app_env_path}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${app_env_path}"
+  set +a
+fi
+
+app_image="${APP_IMAGE:-codex-agent:local}"
+
+exec docker pull "${app_image}"

--- a/deploy/server/up.sh
+++ b/deploy/server/up.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+app_env_path="${APP_ENV_PATH:-/etc/codex-agent/app.env}"
+
+cd "${repo_root}"
+
+exec docker compose \
+  --env-file "${app_env_path}" \
+  -f compose.yaml \
+  -f compose.server.yaml \
+  up -d "$@"

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 4. 必要に応じて運用ガイド
    - [Slack API Setup](./slack-api-setup.md)
    - [Docker Guide](./docker.md)
+   - [Remote Deploy Guide](./deploy-remote.md)
 
 ## Document roles
 
@@ -27,6 +28,8 @@
   - Slack App の設定手順
 - `docker.md`
   - Docker での運用手順
+- `deploy-remote.md`
+  - remote Docker host への配置手順
 
 ## Historical documents
 

--- a/docs/deploy-remote.md
+++ b/docs/deploy-remote.md
@@ -26,7 +26,7 @@
 - Playwright profile: `/srv/codex-agent/playwright-agent-profile`
 - SQLite: `/srv/codex-agent/data/app.sqlite`
 
-必要に応じて `HOST_STATE_ROOT` で state root を変えられる。
+必要に応じて `HOST_STATE_ROOT` で state root を変えられる。初回 bootstrap 前に変えたい場合は、`HOST_STATE_ROOT=/your/path deploy/server/bootstrap.sh` のように shell 側で渡す。
 
 ## 初期セットアップ
 

--- a/docs/deploy-remote.md
+++ b/docs/deploy-remote.md
@@ -1,0 +1,123 @@
+# Remote Deploy Guide
+
+このドキュメントは、`codex-agent` を remote Docker host へ置く手順をまとめる。  
+ここでは Lightsail Instance のような、Docker Compose を使える汎用 Linux host を前提にする。
+
+## 前提
+
+- Docker と Docker Compose が導入済み
+- この repo を host 上に配置済み
+- Slack App の token を発行済み
+- Codex CLI を container 内で使う運用を許容する
+
+## 使うファイル
+
+- compose base: `compose.yaml`
+- remote override: `compose.server.yaml`
+- remote env template: `deploy/env/server.env.example`
+- remote helper scripts: `deploy/server/*.sh`
+
+## 使うパス
+
+- repo: 任意の checkout path
+- env file: `/etc/codex-agent/app.env`
+- state root: `/srv/codex-agent`
+- Codex 認証: `/srv/codex-agent/codex-home`
+- Playwright profile: `/srv/codex-agent/playwright-agent-profile`
+- SQLite: `/srv/codex-agent/data/app.sqlite`
+
+必要に応じて `HOST_STATE_ROOT` で state root を変えられる。
+
+## 初期セットアップ
+
+1. state ディレクトリを作る
+
+```bash
+deploy/server/bootstrap.sh
+```
+
+2. env file を配置する
+
+```bash
+sudo mkdir -p /etc/codex-agent
+sudo cp deploy/env/server.env.example /etc/codex-agent/app.env
+sudo chmod 600 /etc/codex-agent/app.env
+```
+
+3. `/etc/codex-agent/app.env` を編集する
+
+最低限、次を設定する。
+
+- `SLACK_BOT_TOKEN`
+- `SLACK_APP_TOKEN`
+
+`APP_IMAGE` は運用に合わせて選ぶ。
+
+- host build を使うなら `codex-agent:local`
+- pull 運用なら pull 可能な image tag
+
+## image を用意する
+
+host build の場合:
+
+```bash
+deploy/server/build.sh
+```
+
+pullable image を使う場合:
+
+```bash
+deploy/server/pull.sh
+```
+
+## 起動
+
+```bash
+deploy/server/up.sh
+```
+
+ログ確認:
+
+```bash
+deploy/server/logs.sh
+```
+
+## 初回 Codex 認証
+
+container 起動後、device auth でログインする。
+
+```bash
+deploy/server/login-codex.sh
+```
+
+認証状態は `/srv/codex-agent/codex-home` に残るため、container 再起動後も維持される。
+
+## 更新
+
+host build の場合:
+
+```bash
+git pull
+deploy/server/build.sh
+deploy/server/up.sh
+```
+
+pullable image の場合:
+
+```bash
+git pull
+deploy/server/pull.sh
+deploy/server/up.sh
+```
+
+## バックアップ
+
+最低限バックアップ対象にするのは次の 2 つ。
+
+- `/srv/codex-agent/codex-home`
+- `/srv/codex-agent/data`
+
+Playwright の login state を保持したいなら、必要に応じて `/srv/codex-agent/playwright-agent-profile` も含める。
+
+Lightsail では instance snapshot か disk snapshot を使う。  
+永続データを instance root disk から分けたい場合は、state root を別 disk に載せる。

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -155,7 +155,7 @@ deploy/server/pull.sh
 deploy/server/up.sh
 ```
 
-`pull` は `APP_IMAGE` が registry image のときだけ使います。`codex-agent:local` を host build している場合は、`deploy/server/up.sh --build` を使います。
+`pull` は `APP_IMAGE` が registry image のときだけ使います。`codex-agent:local` を host build している場合は、`deploy/server/build.sh` を使います。
 
 Lightsail Instance を前提にした詳細手順は [deploy-remote.md](./deploy-remote.md) を参照してください。
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,7 +3,7 @@
 ## 概要
 
 `codex-agent` を Docker Compose で起動できます。  
-Slack token は外部環境変数から渡し、container 側の Codex 認証は host の通常 `.codex` と分離して `./.docker/codex-home` に保持します。
+実行定義は `compose.yaml` を共通基盤として、local は `compose.override.yaml`、remote は `compose.server.yaml` を重ねます。
 
 app 自体は image 内の `/app` で動作し、Codex worker の作業対象も `/app` です。host の repo は container に bind mount しません。コード変更を反映するには再 build が必要です。base image は `node:24-trixie` を使い、browser は Debian package の `chromium` を入れています。
 
@@ -13,7 +13,19 @@ app 自体は image 内の `/app` で動作し、Codex worker の作業対象も
 - Docker Compose
 - Slack App の設定完了
 
-## 使うパス
+## Compose ファイル
+
+- `compose.yaml`
+  - 共通の service 定義
+- `compose.override.yaml`
+  - local 専用の build と bind mount
+- `compose.server.yaml`
+  - remote 専用の bind mount と restart policy
+
+`docker compose up -d --build` は local で `compose.override.yaml` まで自動で読みます。
+remote は `-f compose.yaml -f compose.server.yaml` を明示します。
+
+## local で使うパス
 
 - Codex 認証: `./.docker/codex-home`
 - Playwright agent profile: `./.docker/playwright-agent-profile`
@@ -21,7 +33,17 @@ app 自体は image 内の `/app` で動作し、Codex worker の作業対象も
 - project local rules/skills: `/app/AGENTS.md`, `/app/.codex/skills`
 - Docker 用 `CODEX_HOME` defaults: `docker/codex-home-defaults/`
 
-これらは bind mount です。host の通常 `.codex` や普段使いの Chrome profile は共有しません。
+これらは local 用 bind mount です。host の通常 `.codex` や普段使いの Chrome profile は共有しません。
+
+## remote で使うパス
+
+- Compose env file: `/etc/codex-agent/app.env`
+- 永続データ root: `/srv/codex-agent`
+- Codex 認証: `/srv/codex-agent/codex-home`
+- Playwright agent profile: `/srv/codex-agent/playwright-agent-profile`
+- SQLite: `/srv/codex-agent/data/app.sqlite`
+
+remote 側の bind mount root は `HOST_STATE_ROOT` で上書きできます。既定値は `/srv/codex-agent` です。
 
 ## rules / skills の扱い
 
@@ -33,16 +55,19 @@ Docker では rules / skills を次の 2 層で分けます。
   - `~/.codex/AGENTS.md`, `~/.codex/skills` へ初回 seed する Docker 用デフォルト
 
 entrypoint は `docker/codex-home-defaults/` だけを `CODEX_HOME` に初回投入します。`~/AGENTS.md` は `~/.codex/AGENTS.md` への symlink として揃えます。`/app/.codex/skills` は自動複製しません。  
-既に `./.docker/codex-home` 側に存在するファイルは保持し、repo 更新で自動上書きはしません。ただし default 側は正常で、seed 済みの `SKILL.md` が壊れている場合だけは起動時に自動修復します。
+既に `CODEX_HOME` 側に存在するファイルは保持し、repo 更新で自動上書きはしません。ただし default 側は正常で、seed 済みの `SKILL.md` が壊れている場合だけは起動時に自動修復します。
 
-デフォルトを再投入したい場合は、対象の `./.docker/codex-home` 側ファイルを削除してから container を再起動します。
+デフォルトを再投入したい場合は、対象の `CODEX_HOME` 側ファイルを削除してから container を再起動します。
 
 ## 環境変数
 
-`.env.example` を `.env` にコピーして値を入れる運用で構いません。Docker Compose が `.env` を読みます。
+local は `.env.example` を `.env` にコピーして値を入れる運用で構いません。Docker Compose が `.env` と `compose.override.yaml` を自動で読みます。
+remote は `deploy/env/server.env.example` を `/etc/codex-agent/app.env` にコピーし、`--env-file` で明示します。
 
 | 変数 | 必須 | 既定値 | 用途 |
 |---|---|---|---|
+| `APP_IMAGE` | 任意 | `codex-agent:local` | compose が使う image 名。local build tag や remote pull 元を切り替える |
+| `HOST_STATE_ROOT` | remote のみ | `/srv/codex-agent` | remote 側 bind mount の root |
 | `SLACK_BOT_TOKEN` | 必須 | なし | Slack Bot Token。メッセージ送信、DM 受信、ファイル操作に使う |
 | `SLACK_APP_TOKEN` | 必須 | なし | Slack App-Level Token。Socket Mode 接続に使う |
 | `SLACK_AGENT_CHAT_STATUS_ENABLED` | 任意 | `false` | `assistant.threads.setStatus` を使うときに `true` にする |
@@ -59,7 +84,7 @@ entrypoint は `docker/codex-home-defaults/` だけを `CODEX_HOME` に初回投
 | `PLAYWRIGHT_AGENT_PROFILE_DIR` | 任意 | `/profiles/agent` | Playwright 用ブラウザ profile の保存先 |
 | `PLAYWRIGHT_MCP_CONFIG` | 任意 | `/run/playwright/cli.config.json` | Playwright MCP の設定ファイルパス |
 
-## 起動
+## local 起動
 
 ```bash
 docker compose up -d --build
@@ -73,7 +98,7 @@ docker compose up -d --build
 docker compose logs -f app
 ```
 
-## 初回 Codex 認証
+## local 初回 Codex 認証
 
 container 内で Codex にログインします。
 
@@ -94,6 +119,46 @@ container 内確認:
 docker compose exec app sh -lc 'echo $CODEX_HOME && echo $CODEX_WORKER_CWD'
 ```
 
+## remote 起動
+
+remote は `compose.server.yaml` と repo 外の env file を明示します。
+
+```bash
+docker compose --env-file /etc/codex-agent/app.env \
+  -f compose.yaml \
+  -f compose.server.yaml \
+  up -d
+```
+
+補助スクリプトも使えます。
+
+```bash
+deploy/server/bootstrap.sh
+deploy/server/build.sh
+deploy/server/pull.sh
+deploy/server/up.sh
+deploy/server/logs.sh
+deploy/server/login-codex.sh
+```
+
+remote 更新:
+
+```bash
+deploy/server/build.sh
+deploy/server/up.sh
+```
+
+registry image を使う場合:
+
+```bash
+deploy/server/pull.sh
+deploy/server/up.sh
+```
+
+`pull` は `APP_IMAGE` が registry image のときだけ使います。`codex-agent:local` を host build している場合は、`deploy/server/up.sh --build` を使います。
+
+Lightsail Instance を前提にした詳細手順は [deploy-remote.md](./deploy-remote.md) を参照してください。
+
 ## timeout / hang 切り分け
 
 `worker execution failed: Error: timed out waiting for worker stream event (300000ms)` が出る場合は、まず `DEBUG_WORKER_EVENTS=true` で最後の worker event を確認してください。通常は高頻度 delta を抑制しているので、ログ量は大きくなりません。
@@ -111,7 +176,7 @@ docker compose logs -f app
 ## Playwright profile
 
 `playwright-cli` は container 内で動きます。  
-profile は `PLAYWRIGHT_AGENT_PROFILE_DIR` に固定され、既定では host の `./.docker/playwright-agent-profile` に保存されます。browser は image 内の `/usr/bin/chromium` を使います。
+profile は `PLAYWRIGHT_AGENT_PROFILE_DIR` に固定され、local では host の `./.docker/playwright-agent-profile`、remote では `${HOST_STATE_ROOT}/playwright-agent-profile` に保存されます。browser は image 内の `/usr/bin/chromium` を使います。
 
 既存の個人用 Chrome profile を直接共有する運用は非推奨です。lock や破損、普段使いブラウザとの競合が起きやすいためです。
 
@@ -119,5 +184,6 @@ profile は `PLAYWRIGHT_AGENT_PROFILE_DIR` に固定され、既定では host �
 
 - app 設定は container 環境変数をそのまま使います
 - Docker は `/app` 固定の image 実行前提で、host repo を live mount しません
+- remote は repo 外の env file と永続データ root を前提にします
 - 今回は秘密情報隔離は最小対応です。worker への env allowlist までは入れていません
 - Playwright 公式 docs の推奨に合わせて `init: true` と `ipc: host` を compose に入れています

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -156,6 +156,7 @@ deploy/server/up.sh
 ```
 
 `pull` は `APP_IMAGE` が registry image のときだけ使います。`codex-agent:local` を host build している場合は、`deploy/server/build.sh` を使います。
+`HOST_STATE_ROOT` を変えて初回 bootstrap したい場合は、`HOST_STATE_ROOT=/your/path deploy/server/bootstrap.sh` のように shell 側で渡します。
 
 Lightsail Instance を前提にした詳細手順は [deploy-remote.md](./deploy-remote.md) を参照してください。
 


### PR DESCRIPTION
## Summary
- split Docker Compose runtime definitions into a shared base plus local and remote overlays
- add remote helper scripts and a server env template for Docker hosts such as Lightsail Instance
- update README and Docker docs for local/remote startup, Codex login, update flow, and backup guidance

## Testing
- `git diff --check`
- `bash -n deploy/server/*.sh`
- `SLACK_BOT_TOKEN=xoxb-test SLACK_APP_TOKEN=xapp-test docker compose config -q`
- `docker compose --env-file deploy/env/server.env.example -f compose.yaml -f compose.server.yaml config -q`

## Notes
- app runtime code is unchanged; this PR only updates Docker/runtime definitions, helper scripts, and docs
- remote helper flow is split into `build.sh` for host builds and `pull.sh` for registry images to avoid ambiguous `up.sh --build` behavior
