### PR TITLE
elicitation確認要求を承認フローに載せる

### DIFF
--- a/src/worker/approval-registry.ts
+++ b/src/worker/approval-registry.ts
@@ -5,6 +5,7 @@ export interface PendingApproval {
   method: string;
   threadId: string;
   turnId: string;
+  params: Record<string, unknown>;
 }
 
 export class ApprovalRegistry {

--- a/src/worker/stdio-jsonrpc-worker-client.ts
+++ b/src/worker/stdio-jsonrpc-worker-client.ts
@@ -178,7 +178,7 @@ export class StdioJsonRpcWorkerClient implements WorkerClient {
 
     await this.respondToServerRequest(
       pendingApproval.requestId,
-      this.protocol.buildApprovalResponse(pendingApproval.method, input.decision),
+      this.protocol.buildApprovalResponse(pendingApproval.method, input.decision, pendingApproval.params),
     );
 
     return this.collectTurnEvents(pendingApproval.threadId, pendingApproval.turnId, options);
@@ -321,7 +321,9 @@ export class StdioJsonRpcWorkerClient implements WorkerClient {
     fallbackThreadId?: string,
     fallbackTurnId?: string,
   ): string | null {
-    if (!this.protocol.isApprovalRequestMethod(streamEvent.method)) {
+    const isApprovalRequest = this.protocol.isApprovalRequestMethod(streamEvent.method);
+    const isApprovalStyleElicitation = this.protocol.supportsApprovalStyleElicitation(streamEvent);
+    if (!isApprovalRequest && !isApprovalStyleElicitation) {
       return null;
     }
 
@@ -338,6 +340,7 @@ export class StdioJsonRpcWorkerClient implements WorkerClient {
       method: streamEvent.method,
       threadId: resolvedThreadId,
       turnId: resolvedTurnId,
+      params: streamEvent.params,
     });
 
     return approvalId;

--- a/src/worker/worker-protocol-adapter.ts
+++ b/src/worker/worker-protocol-adapter.ts
@@ -148,10 +148,32 @@ export class WorkerProtocolAdapter {
     );
   }
 
+  public supportsApprovalStyleElicitation(event: StreamEvent): boolean {
+    if (event.method !== METHODS.elicitationRequest) {
+      return false;
+    }
+
+    const mode = this.asString(event.params.mode);
+    if (mode === 'url') {
+      return true;
+    }
+
+    const requestedSchema = this.asRecord(event.params.requestedSchema);
+    const properties = this.asRecord(requestedSchema.properties);
+    const entries = Object.entries(properties);
+    if (entries.length === 0) {
+      return true;
+    }
+
+    return entries.every(([, definition]) => this.asString(this.asRecord(definition).type) === 'boolean');
+  }
+
   public resolveApprovalId(event: StreamEvent): string {
     return (
       this.asString(event.params.approvalId)
       ?? this.asString(event.params.approval_id)
+      ?? this.asString(event.params.elicitationId)
+      ?? this.asString(event.params.elicitation_id)
       ?? this.asString(event.params.itemId)
       ?? this.asString(event.params.item_id)
       ?? `request-${String(event.id ?? '')}`
@@ -159,6 +181,10 @@ export class WorkerProtocolAdapter {
   }
 
   public buildApprovalPrompt(event: StreamEvent): string {
+    if (event.method === METHODS.elicitationRequest) {
+      return this.buildElicitationPrompt(event.params);
+    }
+
     const reason = this.asString(event.params.reason);
     const command = this.readCommand(event.params.command);
 
@@ -177,7 +203,11 @@ export class WorkerProtocolAdapter {
     return 'Approval required to continue.';
   }
 
-  public buildApprovalResponse(method: string, decision: ApprovalDecision): Record<string, unknown> {
+  public buildApprovalResponse(
+    method: string,
+    decision: ApprovalDecision,
+    params: Record<string, unknown> = {},
+  ): Record<string, unknown> {
     const approve = decision === 'approve';
 
     if (method === METHODS.commandApprovalRequest || method === METHODS.fileChangeApprovalRequest) {
@@ -190,6 +220,10 @@ export class WorkerProtocolAdapter {
       return {
         decision: approve ? 'approved' : 'denied',
       };
+    }
+
+    if (method === METHODS.elicitationRequest) {
+      return this.buildElicitationResponse(decision, params);
     }
 
     throw new Error(`unsupported approval method: ${method}`);
@@ -327,6 +361,65 @@ export class WorkerProtocolAdapter {
 
   private formatCommandCodeBlock(command: string): string {
     return `\`\`\`\n${command}\n\`\`\``;
+  }
+
+  private buildElicitationPrompt(params: Record<string, unknown>): string {
+    const message = this.asString(params.message) ?? 'User confirmation is required to continue.';
+    const mode = this.asString(params.mode);
+    const url = this.asString(params.url);
+
+    if (mode === 'url' && url) {
+      return `${message}\n${url}`;
+    }
+
+    return message;
+  }
+
+  private buildElicitationResponse(
+    decision: ApprovalDecision,
+    params: Record<string, unknown>,
+  ): Record<string, unknown> {
+    if (decision === 'reject') {
+      return { action: 'decline' };
+    }
+
+    const mode = this.asString(params.mode);
+    if (mode === 'url') {
+      return { action: 'accept' };
+    }
+
+    const content = this.buildBooleanElicitationContent(params, true);
+    if (content) {
+      return {
+        action: 'accept',
+        content,
+      };
+    }
+
+    return { action: 'accept' };
+  }
+
+  private buildBooleanElicitationContent(
+    params: Record<string, unknown>,
+    value: boolean,
+  ): Record<string, boolean> | null {
+    const requestedSchema = this.asRecord(params.requestedSchema);
+    const properties = this.asRecord(requestedSchema.properties);
+    const entries = Object.entries(properties);
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    const content: Record<string, boolean> = {};
+    for (const [key, definition] of entries) {
+      if (this.asString(this.asRecord(definition).type) !== 'boolean') {
+        return null;
+      }
+      content[key] = value;
+    }
+
+    return content;
   }
 
   private readCommand(value: unknown): string | null {

--- a/tests/fixtures/mock-worker.mjs
+++ b/tests/fixtures/mock-worker.mjs
@@ -236,6 +236,52 @@ rl.on('line', (line) => {
         return;
       }
 
+      if (text.includes('[ELICIT_APPROVAL]')) {
+        const requestId = request('mcpServer/elicitation/request', {
+          threadId,
+          turnId,
+          elicitationId: `elicitation-${turnCount}`,
+          message: 'Allow Linear MCP Server to run tool "linear mcp server_save_project"?',
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              allow: {
+                type: 'boolean',
+                title: 'Allow',
+              },
+            },
+            required: ['allow'],
+          },
+        });
+        pendingApprovalRequests.set(requestId, {
+          threadId,
+          turnId,
+          approvalId: `elicitation-${turnCount}`,
+          kind: 'elicitation',
+        });
+        return;
+      }
+
+      if (text.includes('[ELICIT_COMPLEX]')) {
+        request('mcpServer/elicitation/request', {
+          threadId,
+          turnId,
+          elicitationId: `elicitation-${turnCount}`,
+          message: 'Project name is required.',
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              projectName: {
+                type: 'string',
+                title: 'Project Name',
+              },
+            },
+            required: ['projectName'],
+          },
+        });
+        return;
+      }
+
       if (text.includes('[STALL]')) {
         emitAgentMessage(threadId, turnId, `processing:${text}`, 'commentary');
         return;
@@ -287,7 +333,9 @@ rl.on('line', (line) => {
 
     pendingApprovalRequests.delete(msg.id);
 
-    const decision = msg?.result?.decision;
+    const decision = pending.kind === 'elicitation'
+      ? msg?.result?.action
+      : msg?.result?.decision;
     const label = normalizeDecisionLabel(decision);
 
     emitAgentMessage(pending.threadId, pending.turnId, `approval:${label}`, 'commentary');

--- a/tests/specs/worker/approval-registry.test.ts
+++ b/tests/specs/worker/approval-registry.test.ts
@@ -10,6 +10,7 @@ test('approval registry returns an approval once and removes it from the registr
     method: 'execCommandApproval',
     threadId: 'thread-1',
     turnId: 'turn-1',
+    params: {},
   });
 
   assert.deepEqual(registry.consume('approval-1'), {
@@ -17,6 +18,7 @@ test('approval registry returns an approval once and removes it from the registr
     method: 'execCommandApproval',
     threadId: 'thread-1',
     turnId: 'turn-1',
+    params: {},
   });
   assert.equal(registry.consume('approval-1'), null);
 });

--- a/tests/specs/worker/worker-protocol-adapter.test.ts
+++ b/tests/specs/worker/worker-protocol-adapter.test.ts
@@ -35,3 +35,29 @@ test('worker protocol adapter extracts completed final answers from item/complet
 
   assert.deepEqual(message, { text: 'final', phase: 'final_answer' });
 });
+
+test('worker protocol adapter converts approval-style elicitation decisions into MCP elicitation results', () => {
+  const adapter = createAdapter();
+
+  const result = adapter.buildApprovalResponse(
+    'mcpServer/elicitation/request',
+    'approve',
+    {
+      requestedSchema: {
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'boolean',
+          },
+        },
+      },
+    },
+  );
+
+  assert.deepEqual(result, {
+    action: 'accept',
+    content: {
+      allow: true,
+    },
+  });
+});

--- a/tests/specs/worker/worker-runtime.integration.test.ts
+++ b/tests/specs/worker/worker-runtime.integration.test.ts
@@ -46,6 +46,64 @@ test('worker runtime fails immediately with method context when user-input reque
   await worker.close();
 });
 
+test('worker runtime surfaces approval-style elicitation requests and resumes after approval', async () => {
+  const worker = new StdioJsonRpcWorkerClient(process.execPath, [fixturePath()]);
+  const { codex_thread_id } = await worker.createThread();
+
+  const approvalEvents = await worker.sendUserMessage({
+    codex_thread_id,
+    text: '[ELICIT_APPROVAL]',
+    user_id: 'U1',
+  });
+
+  assert.deepEqual(approvalEvents, [
+    {
+      type: 'approval_required',
+      approval_id: 'elicitation-1',
+      prompt: 'Allow Linear MCP Server to run tool "linear mcp server_save_project"?',
+    },
+  ]);
+
+  const completedEvents = await worker.sendApprovalDecision({
+    codex_thread_id,
+    approval_id: 'elicitation-1',
+    decision: 'approve',
+  });
+
+  assert.deepEqual(completedEvents, [
+    {
+      type: 'progress',
+      message: 'approval:approve',
+    },
+    {
+      type: 'completed',
+      message: 'approval-complete:approve',
+    },
+  ]);
+
+  await worker.close();
+});
+
+test('worker runtime still fails fast for elicitation requests that need structured input', async () => {
+  const worker = new StdioJsonRpcWorkerClient(process.execPath, [fixturePath()]);
+  const { codex_thread_id } = await worker.createThread();
+
+  const events = await worker.sendUserMessage({
+    codex_thread_id,
+    text: '[ELICIT_COMPLEX]',
+    user_id: 'U1',
+  });
+
+  assert.deepEqual(events, [
+    {
+      type: 'failed',
+      error: 'worker requested unsupported client interaction: mcpServer/elicitation/request (Project name is required.)',
+    },
+  ]);
+
+  await worker.close();
+});
+
 test('worker runtime still surfaces approval requests when thread and turn ids are omitted', async () => {
   const worker = new StdioJsonRpcWorkerClient(process.execPath, [fixturePath()]);
   const { codex_thread_id } = await worker.createThread();


### PR DESCRIPTION
- 変更理由: mcpServer/elicitation/request が unsupported client interaction で失敗していたため
- 変更内容: yes/no 相当の elicitation を approval_required に変換し、approve/reject を MCP 応答へ変換
- 動作確認: npm run check
- 動作確認: npm test -- tests/specs/worker/approval-registry.test.ts tests/specs/worker/worker-protocol-adapter.test.ts tests/specs/worker/worker-runtime.integration.test.ts