### PR TITLE
[codex] approval-style elicitation の判定を厳格化

### DIFF
--- a/src/gateway/bolt.ts
+++ b/src/gateway/bolt.ts
@@ -4,7 +4,13 @@ import { basename, extname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { promisify } from 'node:util';
 import { App } from '@slack/bolt';
-import { Gateway, type SlackApprovalAction, type SlackMessageEvent, type SlackPublisher } from './gateway.js';
+import {
+  Gateway,
+  toSlackApprovalPrompt,
+  type SlackApprovalAction,
+  type SlackMessageEvent,
+  type SlackPublisher,
+} from './gateway.js';
 
 export interface BoltGatewayRuntime {
   app: App;
@@ -266,7 +272,7 @@ export function buildResolvedApprovalBlocks(
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: prompt,
+        text: toSlackApprovalPrompt(prompt),
       },
     },
     {
@@ -289,6 +295,11 @@ export function readApprovalPrompt(body: any, fallback?: string): string {
   const text = body?.message?.blocks?.[0]?.text?.text;
   if (typeof text === 'string' && text.trim() !== '') {
     return text;
+  }
+
+  const plainText = body?.message?.text;
+  if (typeof plainText === 'string' && plainText.trim() !== '') {
+    return plainText;
   }
 
   if (typeof fallback === 'string' && fallback.trim() !== '') {

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -63,6 +63,8 @@ export interface SlackApprovalAction {
   decision: ApprovalDecision;
 }
 
+const SLACK_APPROVAL_PROMPT_BLOCK_LIMIT = 3000;
+
 export class Gateway implements GatewayNotifier {
   private readonly pendingAttachmentDirectories = new Map<string, string>();
 
@@ -208,8 +210,8 @@ export class Gateway implements GatewayNotifier {
       channel_id: session.slack_channel_id,
       root_thread_ts: session.slack_root_thread_ts,
       approval_id: approval.approval_id,
-      prompt: approval.prompt,
     });
+    const displayPrompt = toSlackApprovalPrompt(approval.prompt);
 
     await this.publisher.postThreadMessage({
       channel_id: session.slack_channel_id,
@@ -220,7 +222,7 @@ export class Gateway implements GatewayNotifier {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: approval.prompt,
+            text: displayPrompt,
           },
         },
         {
@@ -301,6 +303,15 @@ export class Gateway implements GatewayNotifier {
     }
   }
 }
+
+export function toSlackApprovalPrompt(prompt: string): string {
+  if (prompt.length <= SLACK_APPROVAL_PROMPT_BLOCK_LIMIT) {
+    return prompt;
+  }
+
+  return `${prompt.slice(0, SLACK_APPROVAL_PROMPT_BLOCK_LIMIT - 1).trimEnd()}…`;
+}
+
 export {
   extractLocalImageFiles,
   renderSlackCompletedMessage,

--- a/src/worker/worker-protocol-adapter.ts
+++ b/src/worker/worker-protocol-adapter.ts
@@ -153,19 +153,7 @@ export class WorkerProtocolAdapter {
       return false;
     }
 
-    const mode = this.asString(event.params.mode);
-    if (mode === 'url') {
-      return true;
-    }
-
-    const requestedSchema = this.asRecord(event.params.requestedSchema);
-    const properties = this.asRecord(requestedSchema.properties);
-    const entries = Object.entries(properties);
-    if (entries.length === 0) {
-      return true;
-    }
-
-    return entries.every(([, definition]) => this.asString(this.asRecord(definition).type) === 'boolean');
+    return this.readApprovalBooleanElicitationKey(event.params) !== null;
   }
 
   public resolveApprovalId(event: StreamEvent): string {
@@ -383,43 +371,52 @@ export class WorkerProtocolAdapter {
       return { action: 'decline' };
     }
 
-    const mode = this.asString(params.mode);
-    if (mode === 'url') {
-      return { action: 'accept' };
+    const approvalKey = this.readApprovalBooleanElicitationKey(params);
+    if (!approvalKey) {
+      throw new Error('unsupported elicitation approval response');
     }
 
-    const content = this.buildBooleanElicitationContent(params, true);
-    if (content) {
-      return {
-        action: 'accept',
-        content,
-      };
-    }
-
-    return { action: 'accept' };
+    return {
+      action: 'accept',
+      content: {
+        [approvalKey]: true,
+      },
+    };
   }
 
-  private buildBooleanElicitationContent(
-    params: Record<string, unknown>,
-    value: boolean,
-  ): Record<string, boolean> | null {
-    const requestedSchema = this.asRecord(params.requestedSchema);
-    const properties = this.asRecord(requestedSchema.properties);
-    const entries = Object.entries(properties);
-
-    if (entries.length === 0) {
+  private readApprovalBooleanElicitationKey(params: Record<string, unknown>): string | null {
+    if (this.asString(params.mode) === 'url') {
       return null;
     }
 
-    const content: Record<string, boolean> = {};
-    for (const [key, definition] of entries) {
-      if (this.asString(this.asRecord(definition).type) !== 'boolean') {
-        return null;
-      }
-      content[key] = value;
+    const requestedSchema = this.asRecord(params.requestedSchema);
+    const properties = this.asRecord(requestedSchema.properties);
+    const entries = Object.entries(properties);
+    if (entries.length !== 1) {
+      return null;
     }
 
-    return content;
+    const entry = entries[0];
+    if (!entry) {
+      return null;
+    }
+
+    const [key, definition] = entry;
+    const definitionRecord = this.asRecord(definition);
+    if (this.asString(definitionRecord.type) !== 'boolean') {
+      return null;
+    }
+
+    if ('default' in definitionRecord) {
+      return null;
+    }
+
+    const required = requestedSchema.required;
+    if (!Array.isArray(required) || required.length !== 1 || required[0] !== key) {
+      return null;
+    }
+
+    return key;
   }
 
   private readCommand(value: unknown): string | null {

--- a/tests/fixtures/mock-worker.mjs
+++ b/tests/fixtures/mock-worker.mjs
@@ -282,6 +282,42 @@ rl.on('line', (line) => {
         return;
       }
 
+      if (text.includes('[ELICIT_URL]')) {
+        request('mcpServer/elicitation/request', {
+          threadId,
+          turnId,
+          elicitationId: `elicitation-url-${turnCount}`,
+          mode: 'url',
+          message: 'Open the browser flow to continue.',
+          url: 'https://example.com/oauth',
+        });
+        return;
+      }
+
+      if (text.includes('[ELICIT_MULTI_BOOLEAN]')) {
+        request('mcpServer/elicitation/request', {
+          threadId,
+          turnId,
+          elicitationId: `elicitation-multi-${turnCount}`,
+          message: 'Choose approval options.',
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              allow: {
+                type: 'boolean',
+                title: 'Allow',
+              },
+              remember: {
+                type: 'boolean',
+                title: 'Remember',
+              },
+            },
+            required: ['allow'],
+          },
+        });
+        return;
+      }
+
       if (text.includes('[STALL]')) {
         emitAgentMessage(threadId, turnId, `processing:${text}`, 'commentary');
         return;

--- a/tests/specs/gateway/presentation.test.ts
+++ b/tests/specs/gateway/presentation.test.ts
@@ -328,3 +328,36 @@ test('gateway routing keeps attachment files until approval is resolved', async 
 
   assert.equal(existsSync(tempPath), false);
 });
+
+test('gateway approval presentation truncates oversized prompts for blocks and keeps action payload compact', async () => {
+  const posted: Array<{ text: string; blocks?: unknown[] }> = [];
+  const gateway = new Gateway(
+    {} as any,
+    {
+      postThreadMessage: async (input) => {
+        posted.push({ text: input.text, blocks: input.blocks });
+      },
+      uploadThreadFiles: async () => {},
+      setThreadStatus: async () => {},
+    },
+  );
+
+  const prompt = 'x'.repeat(4000);
+  await gateway.notifyApproval(createSession(), {
+    approval_id: 'approval-1',
+    prompt,
+  });
+
+  const message = posted[0];
+  assert.equal(message?.text, prompt);
+  assert.equal(((message?.blocks?.[0] as any)?.text?.text as string).length <= 3000, true);
+
+  const actionValue = ((message?.blocks?.[1] as any)?.elements?.[0]?.value as string) ?? '';
+  assert.equal(actionValue.length <= 2000, true);
+  assert.deepEqual(JSON.parse(actionValue), {
+    team_id: 'T1',
+    channel_id: 'D1',
+    root_thread_ts: '100.1',
+    approval_id: 'approval-1',
+  });
+});

--- a/tests/specs/gateway/slack-approval-ui.test.ts
+++ b/tests/specs/gateway/slack-approval-ui.test.ts
@@ -15,6 +15,12 @@ test('Slack approval UI replaces decision buttons with the chosen result after a
   assert.match((blocks[1] as any).elements[0].text, /Approve/);
 });
 
+test('Slack approval UI truncates oversized prompts so resolved blocks stay within Slack limits', () => {
+  const blocks = buildResolvedApprovalBlocks('x'.repeat(4000), 'approve');
+
+  assert.equal((((blocks[0] as any).text?.text) as string).length <= 3000, true);
+});
+
 test('Slack approval UI targets the container message timestamp first when updating an action response', () => {
   assert.equal(
     getActionMessageTs({
@@ -27,4 +33,15 @@ test('Slack approval UI targets the container message timestamp first when updat
 
 test('Slack approval UI falls back to the payload text when approval blocks are unavailable', () => {
   assert.equal(readApprovalPrompt({}, 'approve this?'), 'approve this?');
+});
+
+test('Slack approval UI falls back to the plain message text before legacy action payloads', () => {
+  assert.equal(
+    readApprovalPrompt({
+      message: {
+        text: 'full approval prompt',
+      },
+    }, 'truncated prompt'),
+    'full approval prompt',
+  );
 });

--- a/tests/specs/worker/worker-protocol-adapter.test.ts
+++ b/tests/specs/worker/worker-protocol-adapter.test.ts
@@ -50,6 +50,7 @@ test('worker protocol adapter converts approval-style elicitation decisions into
             type: 'boolean',
           },
         },
+        required: ['allow'],
       },
     },
   );
@@ -60,4 +61,41 @@ test('worker protocol adapter converts approval-style elicitation decisions into
       allow: true,
     },
   });
+});
+
+test('worker protocol adapter does not treat url-mode elicitation as approval-style', () => {
+  const adapter = createAdapter();
+
+  const supported = adapter.supportsApprovalStyleElicitation({
+    kind: 'request',
+    method: 'mcpServer/elicitation/request',
+    params: {
+      mode: 'url',
+      message: 'Open browser',
+      url: 'https://example.com/oauth',
+    },
+  });
+
+  assert.equal(supported, false);
+});
+
+test('worker protocol adapter does not treat multi-boolean elicitation as approval-style', () => {
+  const adapter = createAdapter();
+
+  const supported = adapter.supportsApprovalStyleElicitation({
+    kind: 'request',
+    method: 'mcpServer/elicitation/request',
+    params: {
+      requestedSchema: {
+        type: 'object',
+        properties: {
+          allow: { type: 'boolean' },
+          remember: { type: 'boolean' },
+        },
+        required: ['allow'],
+      },
+    },
+  });
+
+  assert.equal(supported, false);
 });

--- a/tests/specs/worker/worker-runtime.integration.test.ts
+++ b/tests/specs/worker/worker-runtime.integration.test.ts
@@ -104,6 +104,46 @@ test('worker runtime still fails fast for elicitation requests that need structu
   await worker.close();
 });
 
+test('worker runtime keeps url-mode elicitation unsupported without a dedicated completion flow', async () => {
+  const worker = new StdioJsonRpcWorkerClient(process.execPath, [fixturePath()]);
+  const { codex_thread_id } = await worker.createThread();
+
+  const events = await worker.sendUserMessage({
+    codex_thread_id,
+    text: '[ELICIT_URL]',
+    user_id: 'U1',
+  });
+
+  assert.deepEqual(events, [
+    {
+      type: 'failed',
+      error: 'worker requested unsupported client interaction: mcpServer/elicitation/request (Open the browser flow to continue.)',
+    },
+  ]);
+
+  await worker.close();
+});
+
+test('worker runtime keeps multi-boolean elicitation unsupported to avoid collapsing choices', async () => {
+  const worker = new StdioJsonRpcWorkerClient(process.execPath, [fixturePath()]);
+  const { codex_thread_id } = await worker.createThread();
+
+  const events = await worker.sendUserMessage({
+    codex_thread_id,
+    text: '[ELICIT_MULTI_BOOLEAN]',
+    user_id: 'U1',
+  });
+
+  assert.deepEqual(events, [
+    {
+      type: 'failed',
+      error: 'worker requested unsupported client interaction: mcpServer/elicitation/request (Choose approval options.)',
+    },
+  ]);
+
+  await worker.close();
+});
+
 test('worker runtime still surfaces approval requests when thread and turn ids are omitted', async () => {
   const worker = new StdioJsonRpcWorkerClient(process.execPath, [fixturePath()]);
   const { codex_thread_id } = await worker.createThread();


### PR DESCRIPTION
## Summary
- approval-style elicitation として扱う条件を「required な単一 boolean フィールドのみ」に限定
- `url` モードと複数 boolean の elicitation を unsupported 扱いにするテストを追加
- mock worker に `url` モードと複数 boolean の fixture を追加

## Why
既存実装では `url` モードや複数 boolean の elicitation も approval フローへ寄せて扱えてしまい、必要な対話や選択肢を潰す余地がありました。今回の変更で、単純な承認/拒否に安全に落とし込めるケースだけを approval-style として扱います。

## Validation
- `./node_modules/.bin/tsx --test tests/specs/worker/worker-protocol-adapter.test.ts tests/specs/worker/worker-runtime.integration.test.ts`

## Impact
worker runtime は、専用の完了フローがない `url` モードや複数選択系 elicitation を引き続き失敗として明示し、誤った自動承認を避けます。