### PR TITLE
PR #8 レビュー指摘の追従修正 (#15-21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ export REDIS_URL='redis://localhost:6379'
 - `WORKER_STREAM_EVENT_TIMEOUT_MS`
 - `SLACK_AGENT_CHAT_STATUS_ENABLED`
 - `SLACK_ATTACHMENT_MAX_BYTES`
+- `SLACK_ATTACHMENT_TMP_DIR`
 - `DEBUG_SLACK_EVENTS`
 - `DEBUG_WORKER_EVENTS`
 - `DEBUG_WORKER_EVENT_DELTAS`
@@ -182,17 +183,18 @@ CODEX_WORKER_CWD=/app
 WORKER_STREAM_EVENT_TIMEOUT_MS=300000
 SLACK_AGENT_CHAT_STATUS_ENABLED=false
 SLACK_ATTACHMENT_MAX_BYTES=10485760
+SLACK_ATTACHMENT_TMP_DIR=
 ```
 
 remote 用テンプレートは `deploy/env/server.env.example` を使います。`HOST_STATE_ROOT` は remote 専用 compose 変数で、既定値は `/srv/codex-agent` です。
 
 `SLACK_AGENT_CHAT_STATUS_ENABLED=true` にすると、進捗通知に `assistant.threads.setStatus` を使います。classic な DM スレッド返信を維持したい場合は、Slack App 側の `Agent or Assistant` は OFF にしてください。
 
-DM の流れは、初回投稿を `onDirectMessage`、その後の継続投稿を `onSubscribedMessage` として扱います。会話の継続に必要な最小状態は Chat SDK の `thread.state` に置き、SQLite の移行手順はありません。
+DM の流れは、初回投稿を `onDirectMessage`、その後の継続投稿を `onSubscribedMessage` として扱います。会話の継続に必要な最小状態は Chat SDK の `thread.state` に置き、SQLite の移行手順はありません。旧 sqlite ベースのセッションモデルから本ビルドへ初回アップグレードした際は、進行中のセッションと未処理 approval はリセットされます。
 
 Chat SDK の Slack Socket Mode を使います。public webhook URL は不要で、`SLACK_APP_TOKEN` を使って Slack へ WebSocket 接続します。
 
-通常回答の completed メッセージは、送信直前に Markdown を Slack 向けテキストへ整形します。箇条書きは `* `、番号付きリストは `1. ` の行構造を保つようにしています。ローカル画像パス（`/tmp/...png` など）が含まれる場合は、本文から取り除いたうえで thread にファイル添付します。Slack で受け取った添付ファイルは bot token の `files:read` で download し、一時ファイルのパスを worker に渡します。画像・PDF・テキスト系のうち PDF とテキスト系は内容プレビューも worker 入力へ埋め込みます。プレビュー対象外の MIME (zip, docx, バイナリなど) もパスは worker に渡され、codex 側のツールで読み込めます。サイズ上限超過 (`SLACK_ATTACHMENT_MAX_BYTES`、既定 10 MiB) は thread に warning を返し、turn 後に一時ディレクトリを cleanup します。approval と status は今回の変換対象外です。
+通常回答の completed メッセージは、送信直前に Markdown を Slack 向けテキストへ整形します。箇条書きは `* `、番号付きリストは `1. ` の行構造を保つようにしています。ローカル画像パス（`/tmp/...png` など）が含まれる場合は、本文から取り除いたうえで thread にファイル添付します。Slack で受け取った添付ファイルは bot token の `files:read` で download し、一時ファイルのパスを worker に渡します。画像・PDF・テキスト系のうち PDF とテキスト系は内容プレビューも worker 入力へ埋め込みます。プレビュー対象外の MIME (zip, docx, バイナリなど) もパスは worker に渡され、codex 側のツールで読み込めます。サイズ上限超過 (`SLACK_ATTACHMENT_MAX_BYTES`、既定 10 MiB) は thread に warning を返し、turn 後に一時ディレクトリを cleanup します。一時ディレクトリの親パスは `SLACK_ATTACHMENT_TMP_DIR` で指定でき、未指定なら OS の `tmpdir()` を使います。approval と status は今回の変換対象外です。
 
 DM では管理コマンドも使えます。Slack の slash command ではなく通常メッセージとして送ります。先頭の空白は任意です。
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,6 +13,7 @@ export interface AppConfig {
   workerCwd?: string;
   workerStreamEventTimeoutMs: number;
   slackAttachmentMaxBytes: number;
+  slackAttachmentTmpDir?: string;
 }
 
 export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): AppConfig {
@@ -43,6 +44,10 @@ export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): AppConf
     'SLACK_AGENT_CHAT_STATUS_ENABLED',
     false,
   );
+  const slackAttachmentTmpDir = readOptionalString(
+    env.SLACK_ATTACHMENT_TMP_DIR,
+    'SLACK_ATTACHMENT_TMP_DIR',
+  );
 
   return {
     slackBotToken,
@@ -56,6 +61,7 @@ export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): AppConf
     workerCwd: workerCwd ? expandHome(workerCwd) : undefined,
     workerStreamEventTimeoutMs,
     slackAttachmentMaxBytes,
+    slackAttachmentTmpDir: slackAttachmentTmpDir ? expandHome(slackAttachmentTmpDir) : undefined,
   };
 }
 

--- a/src/gateway/chat-sdk.tsx
+++ b/src/gateway/chat-sdk.tsx
@@ -3,9 +3,15 @@
 import { createSlackAdapter, type SlackAdapter } from '@chat-adapter/slack';
 import { Chat, type StateAdapter } from 'chat';
 import { buildResolvedApprovalCard } from './gateway-cards.js';
-import type { Gateway, GatewayApprovalAction } from './gateway.js';
+import type { Gateway, GatewayApprovalAction, GatewayThread } from './gateway.js';
 import type { ThreadSessionState } from '../domain/types.js';
 import { buildSlackMessageEvent, type RawSlackMessageEvent } from './slack-message-event.js';
+
+// Chat SDK の thread 型 (state が Promise を許容するなど) と Gateway 側で扱う
+// GatewayThread の差分を吸収する。共通の as 経由にすることでキャストを 1 箇所にまとめる。
+function asGatewayThread(thread: unknown): GatewayThread {
+  return thread as GatewayThread;
+}
 
 export interface ChatGatewayRuntime {
   bot: Chat<{ slack: SlackAdapter }, ThreadSessionState>;
@@ -20,6 +26,7 @@ interface ChatGatewayRuntimeConfig {
   botUserName: string;
   state: StateAdapter;
   slackAttachmentMaxBytes: number;
+  slackAttachmentTmpDir?: string;
 }
 
 type ApprovalActionPayload = {
@@ -50,13 +57,14 @@ export function createChatGatewayRuntime(
       message.raw as RawSlackMessageEvent,
       config.botToken,
       config.slackAttachmentMaxBytes,
+      { tmpDir: config.slackAttachmentTmpDir },
     );
     if (!slackEvent) {
       return;
     }
 
     await thread.subscribe();
-    await gateway.handleMessage(thread as any, slackEvent);
+    await gateway.handleMessage(asGatewayThread(thread), slackEvent);
   });
 
   bot.onSubscribedMessage(async (thread, message) => {
@@ -64,12 +72,13 @@ export function createChatGatewayRuntime(
       message.raw as RawSlackMessageEvent,
       config.botToken,
       config.slackAttachmentMaxBytes,
+      { tmpDir: config.slackAttachmentTmpDir },
     );
     if (!slackEvent) {
       return;
     }
 
-    await gateway.handleMessage(thread as any, slackEvent);
+    await gateway.handleMessage(asGatewayThread(thread), slackEvent);
   });
 
   bot.onAction(['approve', 'reject'], async (event) => {
@@ -86,7 +95,7 @@ export function createChatGatewayRuntime(
         decision,
       };
 
-      const approved = await gateway.handleApprovalAction(event.thread as any, action);
+      const approved = await gateway.handleApprovalAction(asGatewayThread(event.thread), action);
       if (!approved) {
         return;
       }
@@ -99,7 +108,17 @@ export function createChatGatewayRuntime(
           decision === 'approve' ? 'Approve' : 'Reject'
         }`,
       });
-    } catch {
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[gateway:approval-action-error]',
+        JSON.stringify({
+          error: String(error),
+          action_id: event.actionId,
+          thread_id: event.threadId,
+          message_id: event.messageId,
+        }),
+      );
       return;
     }
   });

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -157,6 +157,8 @@ export class Gateway {
       return false;
     }
 
+    // state を優先することで、ユーザが古いカードのボタンを押下した場合でも最新の
+    // pendingApprovalId を解決する。worker 側で ID 不一致時はエラーを返す前提。
     const approvalId = state.pendingApprovalId ?? action.approval_id;
     const result = await this.runWorkerFlow({
       thread,

--- a/src/gateway/slack-message-event.ts
+++ b/src/gateway/slack-message-event.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, extname, join } from 'node:path';
 import { promisify } from 'node:util';
@@ -60,15 +60,20 @@ export function toSlackMessageEvent(event: RawSlackMessageEvent): SlackMessageEv
   };
 }
 
+export interface BuildSlackMessageEventOptions {
+  fallback?: { team_id?: string };
+  tmpDir?: string;
+}
+
 export async function buildSlackMessageEvent(
   event: RawSlackMessageEvent,
   botToken: string,
   maxBytes: number,
-  fallback?: { team_id?: string },
+  options: BuildSlackMessageEventOptions = {},
 ): Promise<SlackMessageEvent | null> {
   const baseEvent = toSlackMessageEvent({
     ...event,
-    team_id: event.team_id ?? event.team ?? fallback?.team_id,
+    team_id: event.team_id ?? event.team ?? options.fallback?.team_id,
   });
   if (!baseEvent) {
     return null;
@@ -79,7 +84,7 @@ export async function buildSlackMessageEvent(
   }
 
   try {
-    const downloaded = await downloadSlackFiles(event.files, botToken, maxBytes);
+    const downloaded = await downloadSlackFiles(event.files, botToken, maxBytes, options.tmpDir);
     return {
       ...baseEvent,
       text: appendDownloadedFilesToText(baseEvent.text, downloaded.files),
@@ -123,6 +128,7 @@ async function downloadSlackFiles(
   files: RawSlackMessageEvent['files'],
   botToken: string,
   maxBytes: number,
+  tmpDir?: string,
 ): Promise<{
   directory?: string;
   files: Array<{ path: string; name?: string; mimetype?: string; preview?: string }>;
@@ -132,6 +138,7 @@ async function downloadSlackFiles(
     return { files: [], warnings: [] };
   }
 
+  const baseDir = tmpDir ?? tmpdir();
   let directory: string | undefined;
   const downloaded: Array<{ path: string; name?: string; mimetype?: string; preview?: string }> = [];
   const warnings: string[] = [];
@@ -150,7 +157,12 @@ async function downloadSlackFiles(
         continue;
       }
 
-      directory ??= await mkdtemp(join(tmpdir(), 'codex-agent-slack-files-'));
+      if (directory === undefined) {
+        if (tmpDir) {
+          await mkdir(tmpDir, { recursive: true });
+        }
+        directory = await mkdtemp(join(baseDir, 'codex-agent-slack-files-'));
+      }
       const response = await fetch(sourceUrl, {
         headers: {
           Authorization: `Bearer ${botToken}`,
@@ -295,10 +307,10 @@ function mimeTypeToExtension(mimetype?: string): string {
 
 function formatBytes(value: number): string {
   if (value < 1024 * 1024) {
-    return `${Math.round(value / 102.4) / 10} KB`;
+    return `${(value / 1024).toFixed(1)} KB`;
   }
 
-  return `${Math.round((value / (1024 * 1024)) * 10) / 10} MB`;
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function logSlackAttachmentPreviewError(path: string, mimetype: string | undefined, error: unknown): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,12 +64,9 @@ async function main(): Promise<void> {
     botUserName: config.slackBotUserName,
     state,
     slackAttachmentMaxBytes: config.slackAttachmentMaxBytes,
+    slackAttachmentTmpDir: config.slackAttachmentTmpDir,
   });
 
-  // This release intentionally drops sqlite session migration support.
-  console.warn(
-    '[startup-warning] in-flight sessions and pending approvals from the old sqlite-backed session model are not migrated; the first upgrade to this build resets them.',
-  );
   await runtime.start();
   // eslint-disable-next-line no-console
   console.log('codex-agent started');

--- a/tests/integration/gateway-dm-flow.integration.test.ts
+++ b/tests/integration/gateway-dm-flow.integration.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Gateway } from '../../src/gateway/gateway.js';
+import {
+  buildSlackMessageEvent,
+  type RawSlackMessageEvent,
+} from '../../src/gateway/slack-message-event.js';
+import { MockGatewayThread, MockWorkerClient } from '../support/helpers.js';
+
+test('Gateway DM flow turns a raw Slack DM event into a worker createThread + sendUserMessage call', async () => {
+  const worker = new MockWorkerClient();
+  const gateway = new Gateway(worker);
+  const thread = new MockGatewayThread();
+
+  const raw: RawSlackMessageEvent = {
+    team: 'T1',
+    channel: 'D1',
+    user: 'U1',
+    text: 'hello world',
+    ts: '100.1',
+    channel_type: 'im',
+  };
+
+  const slackEvent = await buildSlackMessageEvent(raw, 'xoxb-test-token', 10 * 1024 * 1024);
+  assert.ok(slackEvent, 'buildSlackMessageEvent should produce an event for valid DM payloads');
+
+  await gateway.handleMessage(thread as any, slackEvent!);
+
+  assert.deepEqual(worker.callLog, ['createThread', 'sendUserMessage']);
+  assert.equal(worker.sendUserMessageCalls.length, 1);
+  assert.deepEqual(worker.sendUserMessageCalls[0], {
+    codex_thread_id: 'thread-1',
+    user_id: 'U1',
+    text: 'hello world',
+  });
+  assert.ok(thread.setStateCalls.length >= 1);
+  assert.deepEqual(thread.setStateCalls[0]?.state, {
+    codexThreadId: 'thread-1',
+    pendingApprovalId: null,
+  });
+});
+
+test('Gateway DM flow drops non-DM channel events before invoking the worker', async () => {
+  const worker = new MockWorkerClient();
+  const gateway = new Gateway(worker);
+  const thread = new MockGatewayThread();
+
+  const raw: RawSlackMessageEvent = {
+    team: 'T1',
+    channel: 'C1',
+    user: 'U1',
+    text: 'hello',
+    ts: '100.1',
+    channel_type: 'channel',
+  };
+
+  const slackEvent = await buildSlackMessageEvent(raw, 'xoxb-test-token', 10 * 1024 * 1024);
+  assert.ok(slackEvent);
+
+  await gateway.handleMessage(thread as any, slackEvent!);
+
+  assert.deepEqual(worker.callLog, []);
+  assert.deepEqual(thread.postCalls, []);
+});

--- a/tests/specs/gateway/slack-message-event.test.ts
+++ b/tests/specs/gateway/slack-message-event.test.ts
@@ -105,7 +105,7 @@ test('Slack message event mapping can fill team_id from the outer event envelope
     text: 'hello',
     ts: '100.2',
     channel_type: 'im',
-  }, 'xoxb-test', DEFAULT_MAX_BYTES, { team_id: 'T1' });
+  }, 'xoxb-test', DEFAULT_MAX_BYTES, { fallback: { team_id: 'T1' } });
 
   assert.deepEqual(event, {
     team_id: 'T1',


### PR DESCRIPTION
## Summary
PR #8 のレビューで切られた issue #15-21 を 1 ブランチで一括対応。PR #8 ブランチ (spike/chat-sdk-gateway-migration) をベースにスタックしている。

## 対応 issue
- #15 chat-sdk.tsx の approval action catch にエラーログ追加
- #16 gateway.ts handleApprovalAction の approvalId 優先順位に意図コメント追加
- #17 chat-sdk.tsx の \`thread as any\` 3 箇所を \`asGatewayThread\` ヘルパーに集約
- #18 main.ts の sqlite 移行 startup-warning を削除し README に移送
- #19 Slack 添付一時ディレクトリを \`SLACK_ATTACHMENT_TMP_DIR\` env で上書き可能に
- #20 slack-message-event.ts の formatBytes を \`(value/1024).toFixed(1)\` に置換
- #21 Gateway DM flow (Raw Slack event → buildSlackMessageEvent → Gateway → mock worker) の薄い integration test を追加

## Test plan
- [x] \`npm run check\` 成功
- [x] \`npm test\` 67/67 pass
- [ ] PR #8 マージ後、再 rebase / 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)